### PR TITLE
Disable secure flag as default

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -67,7 +67,7 @@ class Operator(CharmBase):
                     "namespace": self.model.name,
                     "port": self.model.config["port"],
                     "secret-key": secret_key,
-                    "secure": True,
+                    "secure": False,
                     "service": self.model.app.name,
                 }
             )

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -115,7 +115,7 @@ def test_main_with_relation(harness):
     assert data["access-key"] == "minio"
     assert data["namespace"] is None
     assert data["port"] == 9000
-    assert data["secure"] is True
+    assert data["secure"] is False
     assert len(data["secret-key"]) == 30
     assert data["service"] == "minio"
 
@@ -147,7 +147,7 @@ def test_main_with_manual_secret(harness):
         "namespace": None,
         "port": 9000,
         "secret-key": "test-key",
-        "secure": True,
+        "secure": False,
         "service": "minio",
     }
     assert harness.charm.model.unit.status == ActiveStatus("")


### PR DESCRIPTION
Enabling HTTPS takes some doing:

https://docs.min.io/docs/how-to-secure-access-to-minio-server-with-tls.html

This was set to True in #12 when it really should've been False