### PR TITLE
Build Charm through tox with local Schemas

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -50,7 +50,8 @@ jobs:
     - name: Install dependencies
       run: |
         set -eux
-        sudo pip3 install charmcraft
+        sudo apt-get install python3-pip tox
+        sudo snap install charmcraft
         sudo snap install juju --classic
         sudo snap install juju-wait --classic
         sudo snap install yq
@@ -64,7 +65,7 @@ jobs:
     - name: Deploy MinIO
       run: |
         set -eux
-        charmcraft build -v
+        tox -e build
         juju deploy ./minio.charm \
           --config secret-key=minio-secret-key \
           --resource oci-image=$(yq eval '.resources.oci-image.upstream-source' metadata.yaml)

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -17,7 +17,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo snap install charm --classic
-        sudo pip3 install charmcraft
+        sudo snap install charmcraft
 
     - name: Publish bundle
       env:
@@ -26,7 +26,7 @@ jobs:
         set -eux
         echo $CHARMSTORE_CREDENTIAL > ~/.go-cookies
         IMAGE_TAG="RELEASE.2021-02-07T01-31-02Z"
-        charmcraft build
+        tox -e build
         docker pull minio/minio:$IMAGE_TAG
         charm push ./minio.charm \
             cs:~minio-charmers/minio \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-ops==1.1.0
+ops==1.2.0
 git+https://github.com/juju-solutions/resource-oci-image@1964d748022b762b9dce6e8bb7bdf12835102c72
-serialized-data-interface==0.2.0
+serialized-data-interface==0.3.1

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,8 @@ setenv =
 deps =
 	-rtest-requirements.txt
 	-rrequirements.txt
+whitelist_externals =
+    charmcraft
 
 [testenv:unit]
 commands =
@@ -19,4 +21,9 @@ commands =
 commands =
     flake8 {toxinidir}/src {toxinidir}/tests
     black --check {toxinidir}/src {toxinidir}/tests
+
+[testenv:build]
+commands =
+    charmcraft build
+    python3 -m serialized_data_interface.local_sdi
 


### PR DESCRIPTION
Adds build step in tox.ini for building the charm and injecting local SDI schemas into the build zip.

Modify GH Actions and integration tests  with new build step