### PR TITLE
Feature/gateway storage endpoint - support for private endpoints for Azure and AWS

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,20 @@ To install MinIO, run:
 
 For more information, see https://juju.is/docs
 
-## Gateway mode
+## Operation Modes
 
-Supported data storage services: s3, azure
+MinIO can be operated in the following modes:
+
+* `server` (default): MinIO stores any data "locally", handling all aspects of the
+  data storage within the deployed workload and storage in cluster
+* `gateway`: MinIO works as a gateway to a separate blob storage (such as Amazon S3),
+  providing an access layer to your data for in-cluster workloads
+
+### Exmple using `gateway` mode
+
+This charm supports using the following backing data storage services:
+* s3
+* azure
 
 To install MinIO in gateway mode for s3, run:
 
@@ -40,8 +51,10 @@ In case of using private endpoints for storage service
 specify `storage-endpoint-service`. This configuration is optional in case of
 using S3 or Azure public endpoints.
 
-If you do not want to share your data storage service credentials with users,
-you can create users in MinIO console with proper permissions for them.
+By default, the backing storage credentials are also used as the credentials
+to connect to the MinIO gateway itself.  If you do not want to share your 
+data storage service credentials with users, you can create users in the
+MinIO console with proper permissions for them.
 
 For more information,
 see: https://docs.min.io/docs/minio-multi-user-quickstart-guide.html

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To install MinIO in gateway mode for s3, run:
 
     juju deploy minio minio-s3-gateway \
         --config mode=gateway \
-        --config gateway_storage_service=s3 \
+        --config gateway-storage-service=s3 \
         --config access-key=<aws_s3_access_key> \
         --config secret-key=<aws_s3_secret_key>
 
@@ -32,9 +32,13 @@ To install MinIO in gateway mode for azure, run:
 
     juju deploy minio minio-azure-gateway \
         --config mode=gateway \
-        --config gateway_storage_service=azure \
+        --config gateway-storage-service=azure \
         --config access-key=<azurestorageaccountname> \
         --config secret-key=<azurestorageaccountkey>
+
+In case of using private endpoints for storage service
+specify `storage-endpoint-service`. This configuration is optional in case of
+using S3 or Azure public endpoints.
 
 If you do not want to share your data storage service credentials with users,
 you can create users in MinIO console with proper permissions for them.

--- a/config.yaml
+++ b/config.yaml
@@ -18,7 +18,11 @@ options:
     type: string
     default: 'server'
     description: "Mode of operations. Possible values: server, gateway"
-  gateway_storage_service:
+  gateway-storage-service:
     type: string
     default: ''
     description: "Storage service used by gateway to store objects. This value is required for gateway mode. Possible values: s3, azure"
+  storage-service-endpoint:
+    type: string
+    default: ''
+    description: "Service endpoint of gateway storage service. This value is optional when using S3 or Azure public API endpoints"

--- a/src/charm.py
+++ b/src/charm.py
@@ -119,16 +119,7 @@ class Operator(CharmBase):
         if model_mode == "server":
             return ["server", "/data"]
         elif model_mode == "gateway":
-            storage = self.model.config.get("gateway_storage_service")
-            if storage:
-                self.log.debug(f"Minio args: gateway, {storage}")
-                return ["gateway", storage]
-            else:
-                raise CheckFailed(
-                    "Minio in gateway mode requires gateway_storage_service "
-                    "configuration. Possible values: s3, azure",
-                    BlockedStatus,
-                )
+            return self._get_minio_args_gateway()
         else:
             error_msg = (
                 f"Model mode {model_mode} is not supported. "
@@ -136,6 +127,22 @@ class Operator(CharmBase):
             )
             self.log.error(error_msg)
             raise CheckFailed(error_msg, BlockedStatus)
+
+    def _get_minio_args_gateway(self):
+        storage = self.model.config.get("gateway-storage-service")
+        if storage:
+            self.log.debug(f"Minio args: gateway, {storage}")
+            endpoint = self.model.config.get("storage-service-endpoint")
+            if endpoint:
+                return ["gateway", storage, endpoint]
+            else:
+                return ["gateway", storage]
+        else:
+            raise CheckFailed(
+                "Minio in gateway mode requires gateway-storage-service "
+                "configuration. Possible values: s3, azure",
+                BlockedStatus,
+            )
 
 
 def _gen_pass() -> str:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -277,7 +277,7 @@ def test_gateway_minio_with_private_endpoint(harness):
             "secret-key": "test-key",
             "mode": "gateway",
             "gateway-storage-service": "azure",
-            "service_endpoint": "http://someendpoint"
+            "storage-service-endpoint": "http://someendpoint",
         }
     )
     harness.begin_with_initial_hooks()


### PR DESCRIPTION
Changes:
- Added gateway storage endpoint to support the private endpoints in Azure and AWS
- Renamed the gateway fields to keep the same naming convention as access and secret key. ("_" to "-")

Tests:
- same as in https://github.com/canonical/minio-operator/pull/27
- additional test of checking the gateway mode with public and private endpoints explicitly put into the configuration