### PR TITLE
Add min-juju-version element to prevent excess PVC creation

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -6,6 +6,7 @@ description: |
   MinIO's high-performance object storage suite is software defined and
   enables customers to build cloud-native data infrastructure for
   machine learning, analytics and application data workloads.
+min-juju-version: "2.9.0"
 series: [kubernetes]
 resources:
   oci-image:


### PR DESCRIPTION
This PR addresses https://github.com/canonical/bundle-kubeflow/issues/425 where a PVC is created per operator, adding the `min-juju-version: 2.9.0` element to prevent that PVC creation.
