### PR TITLE
Minio Console added to the charm configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,16 @@ To install MinIO, run:
 
 For more information, see https://juju.is/docs
 
+## MinIO console
+
+Minio console is available under port 9001. To change this port use
+configuration variable `console-port`, run:
+
+    juju config minio console-port=9999
+
+For more information,
+see [minio-console documentation](https://docs.min.io/minio/baremetal/console/minio-console.html)
+
 ## Operation Modes
 
 MinIO can be operated in the following modes:

--- a/config.yaml
+++ b/config.yaml
@@ -6,6 +6,10 @@ options:
     type: int
     default: 9000
     description: HTTP port
+  console-port:
+    type: int
+    default: 9001
+    description: HTTP port for minio console
   access-key:
     type: string
     default: 'minio'

--- a/src/charm.py
+++ b/src/charm.py
@@ -69,7 +69,11 @@ class Operator(CharmBase):
                             {
                                 "name": "minio",
                                 "containerPort": int(self.model.config["port"]),
-                            }
+                            },
+                            {
+                                "name": "console",
+                                "containerPort": int(self.model.config["console-port"]),
+                            },
                         ],
                         "envConfig": {
                             "minio-secret": {"secret": {"name": "minio-secret"}},
@@ -132,9 +136,9 @@ class Operator(CharmBase):
     def _get_minio_args(self):
         model_mode = self.model.config["mode"]
         if model_mode == "server":
-            return ["server", "/data"]
+            return self._with_console_address(["server", "/data"])
         elif model_mode == "gateway":
-            return self._get_minio_args_gateway()
+            return self._with_console_address(self._get_minio_args_gateway())
         else:
             error_msg = (
                 f"Model mode {model_mode} is not supported. "
@@ -158,6 +162,10 @@ class Operator(CharmBase):
                 "configuration. Possible values: s3, azure",
                 BlockedStatus,
             )
+
+    def _with_console_address(self, minio_args):
+        console_port = str(self.model.config["console-port"])
+        return [*minio_args, "--console-address", ":" + console_port]
 
 
 def _gen_pass() -> str:

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -118,7 +118,9 @@ async def test_connect_to_console(ops_test: OpsTest):
         "minio-deployment-test",
         "--image=curlimages/curl",
         "--",
-        cmd,
+        "curl",
+        "-I",
+        url,
     )
 
     ret_code, stdout, stderr = await ops_test.run(*kubectl_cmd)

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -104,8 +104,6 @@ async def test_connect_to_console(ops_test: OpsTest):
 
     url = f"http://{service_name}.{model_name}.svc.cluster.local:{port}"
 
-    cmd = f"curl -I {url}"
-
     kubectl_cmd = (
         "microk8s",
         "kubectl",

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -104,9 +104,7 @@ async def test_connect_to_console(ops_test: OpsTest):
 
     url = f"http://{service_name}.{model_name}.svc.cluster.local:{port}"
 
-    cmd = (
-        f"curl -I {url} | head -n 1| cut -d$' ' -f2"
-    )
+    cmd = f"curl -I {url} --silent | head -n 1 | cut -d$' ' -f2"
 
     kubectl_cmd = (
         "microk8s",
@@ -120,8 +118,6 @@ async def test_connect_to_console(ops_test: OpsTest):
         "minio-deployment-test",
         "--image=curlimages/curl",
         "--",
-        "sh",
-        "-c",
         cmd,
     )
 
@@ -130,4 +126,4 @@ async def test_connect_to_console(ops_test: OpsTest):
     assert (
         ret_code == 0
     ), f"Test returned code {ret_code} with stdout:\n{stdout}\nstderr:\n{stderr}"
-    assert (stdout == 200)
+    assert (stdout == "200")

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -41,16 +41,12 @@ async def test_connect_client_to_server(ops_test: OpsTest):
     """
     Tests a deployed MinIO app by trying to connect to it from a pod and do trivial actions with it
     """
-    # TODO: This presumes we're using microk8s.  Fix that.
-    #  could just call kubectl and count on the outside environment aliasing it for us?
-    #  or could pass kubectl path in as a variable?
 
     application = ops_test.model.applications[APP_NAME]
     config = await application.get_config()
     port = config["port"]["value"]
     alias = "ci"
     bucket = "testbucket"
-    # TODO: how do I dynamically retrieve the minio k8s service name?
     service_name = APP_NAME
     model_name = ops_test.model_name
     log.info(f"ops_test.model_name = {ops_test.model_name}")
@@ -90,14 +86,10 @@ async def test_connect_to_console(ops_test: OpsTest):
     """
     Tests a deployed MinIO app by trying to connect to the MinIO console
     """
-    # TODO: This presumes we're using microk8s.  Fix that.
-    #  could just call kubectl and count on the outside environment aliasing it for us?
-    #  or could pass kubectl path in as a variable?
 
     application = ops_test.model.applications[APP_NAME]
     config = await application.get_config()
     port = config["console-port"]["value"]
-    # TODO: how do I dynamically retrieve the minio k8s service name?
     service_name = APP_NAME
     model_name = ops_test.model_name
     log.info(f"ops_test.model_name = {ops_test.model_name}")

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -104,7 +104,7 @@ async def test_connect_to_console(ops_test: OpsTest):
 
     url = f"http://{service_name}.{model_name}.svc.cluster.local:{port}"
 
-    cmd = f"curl -I {url} --silent | head -n 1 | cut -d$' ' -f2"
+    cmd = f"curl -I {url}"
 
     kubectl_cmd = (
         "microk8s",
@@ -126,4 +126,3 @@ async def test_connect_to_console(ops_test: OpsTest):
     assert (
         ret_code == 0
     ), f"Test returned code {ret_code} with stdout:\n{stdout}\nstderr:\n{stderr}"
-    assert (stdout == "200")

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -84,3 +84,50 @@ async def test_connect_client_to_server(ops_test: OpsTest):
     assert (
         ret_code == 0
     ), f"Test returned code {ret_code} with stdout:\n{stdout}\nstderr:\n{stderr}"
+
+
+async def test_connect_to_console(ops_test: OpsTest):
+    """
+    Tests a deployed MinIO app by trying to connect to the MinIO console
+    """
+    # TODO: This presumes we're using microk8s.  Fix that.
+    #  could just call kubectl and count on the outside environment aliasing it for us?
+    #  or could pass kubectl path in as a variable?
+
+    application = ops_test.model.applications[APP_NAME]
+    config = await application.get_config()
+    port = config["console-port"]["value"]
+    # TODO: how do I dynamically retrieve the minio k8s service name?
+    service_name = APP_NAME
+    model_name = ops_test.model_name
+    log.info(f"ops_test.model_name = {ops_test.model_name}")
+
+    url = f"http://{service_name}.{model_name}.svc.cluster.local:{port}"
+
+    cmd = (
+        f"curl -I {url} | head -n 1| cut -d$' ' -f2"
+    )
+
+    kubectl_cmd = (
+        "microk8s",
+        "kubectl",
+        "run",
+        "--rm",
+        "-i",
+        "--restart=Never",
+        "--command",
+        f"--namespace={ops_test.model_name}",
+        "minio-deployment-test",
+        "--image=curlimages/curl",
+        "--",
+        "sh",
+        "-c",
+        cmd,
+    )
+
+    ret_code, stdout, stderr = await ops_test.run(*kubectl_cmd)
+
+    assert (
+        ret_code == 0
+    ), f"Test returned code {ret_code} with stdout:\n{stdout}\nstderr:\n{stderr}"
+    assert (stdout == 200)


### PR DESCRIPTION
**Added**:
- minio console port to configuration with the default value of 9001
- minio console port to minio args in container 
- unit tests (or adjusted) to check port value
- README - minio console section

**Tests** - server and gateway mode deployed using default and then changing the port value.