### PR TITLE
Change Gist to canonical owned repository

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -17,7 +17,7 @@ resources:
 provides:
   object-storage:
     interface: object-storage
-    schema: https://gist.githubusercontent.com/knkski/386af79a681326fb1c2a8cb69e5b02d2/raw/1e089582c43df711e8c08a4af2199f4a2edc43d4/object-storage.yaml
+    schema: https://raw.githubusercontent.com/canonical/operator-schemas/master/object-storage.yaml
     versions: [v1]
 storage:
   minio-data:


### PR DESCRIPTION
Change gist to point to canonical/operator-schemas instead of the personal repository of knkski.