### PR TITLE
Refactor integration tests

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -175,7 +175,7 @@ def _gen_pass() -> str:
 
 
 class CheckFailed(Exception):
-    """ Raise this exception if one of the checks in main fails. """
+    """Raise this exception if one of the checks in main fails."""
 
     def __init__(self, msg, status_type=None):
         super().__init__()

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,8 +1,9 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-pytest
-pyyaml
 flake8
 black==20.8b1
 flake8-copyright<0.3
+pytest
+pyyaml
+tenacity<8.1

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,7 +2,7 @@
 # See LICENSE file for licensing details.
 
 flake8
-black==20.8b1
+black
 flake8-copyright<0.3
 pytest
 pyyaml

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -37,12 +37,7 @@ async def test_build_and_deploy(ops_test: OpsTest):
     await ops_test.model.wait_for_idle(timeout=60 * 10)
 
 
-async def test_connect_client_to_server(ops_test: OpsTest):
-    """
-    Tests a deployed MinIO app by trying to connect to it from a pod and do trivial actions with it
-    """
-
-    application = ops_test.model.applications[APP_NAME]
+async def connect_client_to_server(ops_test: OpsTest, application):
     config = await application.get_config()
     port = config["port"]["value"]
     alias = "ci"
@@ -76,7 +71,16 @@ async def test_connect_client_to_server(ops_test: OpsTest):
         minio_cmd,
     )
 
-    ret_code, stdout, stderr = await ops_test.run(*kubectl_cmd)
+    return await ops_test.run(*kubectl_cmd)
+
+
+async def test_connect_client_to_server(ops_test: OpsTest):
+    """
+    Tests a deployed MinIO app by trying to connect to it from a pod and do trivial actions with it
+    """
+
+    application = ops_test.model.applications[APP_NAME]
+    ret_code, stdout, stderr = await connect_client_to_server(ops_test=ops_test, application=application)
 
     assert (
         ret_code == 0

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -52,7 +52,7 @@ async def connect_client_to_server_with_retry(
         access_key=access_key,
         secret_key=secret_key,
     )
-    log.info(f"Trying to connect to minio via mc client")
+    log.info("Trying to connect to minio via mc client")
 
     if ret_code != 0:
         msg = (

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -56,6 +56,7 @@ async def test_connect_client_to_server(ops_test: OpsTest):
     minio_cmd = (
         f"mc alias set {alias} {url} {MINIO_CONFIG['access-key']} {MINIO_CONFIG['secret-key']}"
         f"&& mc mb {alias}/{bucket}"
+        f"&& mc rb {alias}/{bucket}"
     )
 
     kubectl_cmd = (


### PR DESCRIPTION
Refactors existing integration tests to make it easier to reuse the logic for future tests.  This should not affect the function of the tests