### PR TITLE
fix: credential refresh on config change

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -193,7 +193,7 @@ class Operator(CharmBase):
             try:
                 # Try to use a randomly generated default key from the past
                 secret = self._stored.secret_key
-            except KeyError:
+            except AttributeError:
                 # Create and store a randomly generated default key to reuse in future
                 secret = _gen_pass()
                 self._stored.set_default(secret_key=secret)

--- a/src/charm.py
+++ b/src/charm.py
@@ -6,6 +6,7 @@ import logging
 from random import choices
 from string import ascii_uppercase, digits
 from base64 import b64encode
+from hashlib import sha256
 
 from oci_image import OCIImageResource, OCIImageResourceError
 from ops.charm import CharmBase
@@ -26,7 +27,8 @@ class Operator(CharmBase):
         super().__init__(*args)
         self.log = logging.getLogger()
 
-        self._stored.set_default(secret_key=_gen_pass())
+        # Random salt used for hashing config
+        self._stored.set_default(hash_salt=_gen_pass())
 
         self.image = OCIImageResource(self, "oci-image")
 
@@ -53,8 +55,10 @@ class Operator(CharmBase):
             self.model.unit.status = error.status
             return
 
-        secret_key = self.model.config["secret-key"] or self._stored.secret_key
+        secret_key = self._get_secret_key()
         self._send_info(interfaces, secret_key)
+
+        configmap_hash = self._generate_config_hash()
 
         self.model.unit.status = MaintenanceStatus("Setting pod spec")
         self.model.pod.set_spec(
@@ -79,6 +83,11 @@ class Operator(CharmBase):
                             "minio-secret": {
                                 "secret": {"name": f"{self.model.app.name}-secret"}
                             },
+                            # This hash forces a restart for pods whenever we change the config.
+                            # This would ideally be a spec.template.metadata.annotation rather than an environment
+                            # variable (see https://stackoverflow.com/questions/37317003/restart-pods-when-configmap-updates-in-kubernetes/51421527#51421527)  # noqa E403
+                            # but we cannot change that using podspec.
+                            "configmap-hash": configmap_hash,
                         },
                     }
                 ],
@@ -135,6 +144,15 @@ class Operator(CharmBase):
                 }
             )
 
+    def _generate_config_hash(self):
+        """Returns a hash of the current config state"""
+        # Add a randomly generated salt to the config to make it hard to reverse engineer the
+        # secret-key from the password.
+        salt = self._stored.hash_salt
+        all_config = tuple(str(self.model.config[name]) for name in sorted(self.model.config.keys())) + (salt,)
+        config_hash = sha256(".".join(all_config).encode("utf-8"))
+        return config_hash.hexdigest()
+
     def _get_minio_args(self):
         model_mode = self.model.config["mode"]
         if model_mode == "server":
@@ -164,6 +182,24 @@ class Operator(CharmBase):
                 "configuration. Possible values: s3, azure",
                 BlockedStatus,
             )
+
+    def _get_secret_key(self):
+        """Returns the secret key set by config, else returns the randomly generated secret"""
+        config_secret = self.model.config["secret-key"]
+        if config_secret != "":
+            # Use secret specified in config
+            secret = config_secret
+        else:
+            try:
+                # Try to use a randomly generated default key from the past
+                secret = self._stored.secret_key
+            except KeyError:
+                # Create and store a randomly generated default key to reuse in future
+                secret = _gen_pass()
+                self._stored.set_default(secret_key=secret)
+
+        return secret
+
 
     def _with_console_address(self, minio_args):
         console_port = str(self.model.config["console-port"])

--- a/src/charm.py
+++ b/src/charm.py
@@ -84,9 +84,9 @@ class Operator(CharmBase):
                                 "secret": {"name": f"{self.model.app.name}-secret"}
                             },
                             # This hash forces a restart for pods whenever we change the config.
-                            # This would ideally be a spec.template.metadata.annotation rather than an environment
-                            # variable (see https://stackoverflow.com/questions/37317003/restart-pods-when-configmap-updates-in-kubernetes/51421527#51421527)  # noqa E403
-                            # but we cannot change that using podspec.
+                            # This would ideally be a spec.template.metadata.annotation rather
+                            # than an environment variable, but we cannot use that using podspec.
+                            # (see https://stackoverflow.com/questions/37317003/restart-pods-when-configmap-updates-in-kubernetes/51421527#51421527)  # noqa E403
                             "configmap-hash": configmap_hash,
                         },
                     }
@@ -149,7 +149,9 @@ class Operator(CharmBase):
         # Add a randomly generated salt to the config to make it hard to reverse engineer the
         # secret-key from the password.
         salt = self._stored.hash_salt
-        all_config = tuple(str(self.model.config[name]) for name in sorted(self.model.config.keys())) + (salt,)
+        all_config = tuple(
+            str(self.model.config[name]) for name in sorted(self.model.config.keys())
+        ) + (salt,)
         config_hash = sha256(".".join(all_config).encode("utf-8"))
         return config_hash.hexdigest()
 
@@ -199,7 +201,6 @@ class Operator(CharmBase):
                 self._stored.set_default(secret_key=secret)
 
         return secret
-
 
     def _with_console_address(self, minio_args):
         console_port = str(self.model.config["console-port"])

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -183,10 +183,15 @@ async def test_refresh_credentials(ops_test: OpsTest):
     }
     await application.set_config(config)
 
-    # helper raises if failed
-    await connect_client_to_server_with_retry(
-        ops_test=ops_test,
-        application=application,
-        access_key=config["access-key"],
-        secret_key=config["secret-key"],
-    )
+    for attempt in retry_for_60_seconds:
+        log.info(
+            f"Test attempting to connect to minio using mc client (attempt "
+            f"{attempt.retry_state.attempt_number})"
+        )
+        with attempt:
+            await connect_client_to_server(
+                ops_test=ops_test,
+                application=application,
+                access_key=config["access-key"],
+                secret_key=config["secret-key"],
+            )

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -316,25 +316,29 @@ def test_minio_console_port_args(harness):
     "config,hash_salt,expected_hash",
     [
         (  # Standard working case
-                {"access-key": "access-key-value", "secret-key": "secret-key-value"},
-                "hash-salt",
-                "9b25665b7652ab845b909c718f6c66dccb0946a7ef8ddd607b85198d6deabe5f",
+            {"access-key": "access-key-value", "secret-key": "secret-key-value"},
+            "hash-salt",
+            "9b25665b7652ab845b909c718f6c66dccb0946a7ef8ddd607b85198d6deabe5f",
         ),
         (  # Vary the sorted order of keys
-                {"x_last_alphabetical_order": "access-key-value", "secret-key": "secret-key-value"},
-                "hash-salt",
-                "a33e4682a38734508a9c8cb6971761636fefb0225eab0cb897443f1cf1317a07",
+            {
+                "x_last_alphabetical_order": "access-key-value",
+                "secret-key": "secret-key-value",
+            },
+            "hash-salt",
+            "a33e4682a38734508a9c8cb6971761636fefb0225eab0cb897443f1cf1317a07",
         ),
         (  # Vary the access-key
-                {"access-key": "access-key-value1", "secret-key": "secret-key-value"},
-                "hash-salt",
-                "162ba72393a4993626d553f2e64255f0998a70ef1b8ed4ea73652920d014898d",
+            {"access-key": "access-key-value1", "secret-key": "secret-key-value"},
+            "hash-salt",
+            "162ba72393a4993626d553f2e64255f0998a70ef1b8ed4ea73652920d014898d",
         ),
         (  # Vary the salt
-                {"access-key": "access-key-value", "secret-key": "secret-key-value"},
-                "hash-salt1",
-                "82c0d902422d085cfc5d5d652d7ebd78175042705542fe7db9866a259bd06528",
-        ),    ]
+            {"access-key": "access-key-value", "secret-key": "secret-key-value"},
+            "hash-salt1",
+            "82c0d902422d085cfc5d5d652d7ebd78175042705542fe7db9866a259bd06528",
+        ),
+    ],
 )
 def test_generate_config_hash(config, hash_salt, expected_hash, harness):
     ##################
@@ -373,4 +377,5 @@ def test_generate_config_hash(config, hash_salt, expected_hash, harness):
 
 
 # TODO: test get_secret_key
-# TODO: How can I test whether the hash/password gets randomly generated if omitted?  Or can/should I?
+# TODO: How can I test whether the hash/password gets randomly generated if respective config is
+#  omitted?  Or can/should I at all?


### PR DESCRIPTION
Implements handling of changes to Minio's credentials.  Previously, `juju config minio access-key something-new` would not trigger a restart of the Minio workload, thus not actually change the credentials (unless the pod was later deleted).  This PR implements logic to automate this, as well as tests to support it.

This should be reviewed after reviewing #49 as it builds on fixes from that PR. 