### PR TITLE
WIP: Add service-type config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -30,3 +30,7 @@ options:
     type: string
     default: ''
     description: "Service endpoint of gateway storage service. This value is optional when using S3 or Azure public API endpoints"
+  service-type:
+    type: string
+    default: 'ClusterIP'
+    description: "Service type to configure the minio service.  Options are ClusterIP, NodePort, ExternalName, or LoadBalancer"

--- a/src/charm.py
+++ b/src/charm.py
@@ -95,7 +95,29 @@ class Operator(CharmBase):
                                 }.items()
                             },
                         }
-                    ]
+                    ],
+                    "services": [
+                        {
+                            "name": "minio",
+                            "spec": {
+                                "ports": [
+                                    {
+                                        "name": "minio",
+                                        "port": self.model.config["port"],
+                                        "protocol": "TCP",
+                                        "targetPort": self.model.config["port"],
+                                    },
+                                    {
+                                        "name": "console",
+                                        "port": self.model.config["console-port"],
+                                        "protocol": "TCP",
+                                        "targetPort": self.model.config["console-port"],
+                                    },
+                                ],
+                                "type": self.model.config["service-type"],
+                            },
+                        }
+                    ],
                 },
             }
         )

--- a/src/charm.py
+++ b/src/charm.py
@@ -103,15 +103,15 @@ class Operator(CharmBase):
                                 "ports": [
                                     {
                                         "name": "minio",
-                                        "port": self.model.config["port"],
+                                        "port": int(self.model.config["port"]),
                                         "protocol": "TCP",
-                                        "targetPort": self.model.config["port"],
+                                        "targetPort": int(self.model.config["port"]),
                                     },
                                     {
                                         "name": "console",
-                                        "port": self.model.config["console-port"],
+                                        "port": int(self.model.config["console-port"]),
                                         "protocol": "TCP",
-                                        "targetPort": self.model.config["console-port"],
+                                        "targetPort": int(self.model.config["console-port"]),
                                     },
                                 ],
                                 "type": self.model.config["service-type"],


### PR DESCRIPTION
Add juju config for configuring the service-type of the minio service.

Add support for Minio service type configuration in the charm.
Default service type is ClusterIP. 