### PR TITLE
Upgrade black version to 22.3.0 to fix issue with click dependency

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,5 +4,5 @@
 pytest
 pyyaml
 flake8
-black==20.8b1
+black==22.3.0
 flake8-copyright<0.3


### PR DESCRIPTION
Black is broken due to a change in the click dependency and is fixed in version 22.3.0.  Here is a link to the [related issue](https://github.com/psf/black/issues/2964)