### PR TITLE
Run charmcraft-specific Github actions only from the canonical context

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -9,6 +9,20 @@ on:
 
 jobs:
 
+  lib-check:
+    name: Check libraries
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'canonical'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Check libs
+        uses: canonical/charming-actions/check-libraries@1.0.3
+        with:
+          credentials: "${{ secrets.charmcraft-credentials }}"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
 
   lint:
     name: Lint Code

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -12,7 +12,7 @@ jobs:
   lib-check:
     name: Check libraries
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'canonical'
+    if: github.actor == 'canonical'
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -9,20 +9,6 @@ on:
 
 jobs:
 
-  lib-check:
-    name: Check libraries
-    runs-on: ubuntu-latest
-    if: github.repository_owner == 'canonical'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Check libs
-        uses: canonical/charming-actions/check-libraries@1.0.3
-        with:
-          credentials: "${{ secrets.charmcraft-credentials }}"
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
 
   lint:
     name: Lint Code

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -12,6 +12,7 @@ jobs:
   lib-check:
     name: Check libraries
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'canonical'
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -1,4 +1,4 @@
-name: Test
+name: Test on PR
 
 # On pull_request, we:
 # * always publish to charmhub at latest/edge/branchname

--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -14,10 +14,3 @@ jobs:
     uses: ./.github/workflows/integrate.yaml
     secrets:
       charmcraft-credentials: "${{ secrets.CHARMCRAFT_CREDENTIALS }}"
-
-  # publish runs in parallel with tests, as we always publish in this situation
-  publish-charm:
-    name: Publish Charm
-    uses: ./.github/workflows/publish.yaml
-    secrets:
-      charmcraft-credentials: "${{ secrets.CHARMCRAFT_CREDENTIALS }}"

--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -1,4 +1,4 @@
-name: Test and publish to branch
+name: Test
 
 # On pull_request, we:
 # * always publish to charmhub at latest/edge/branchname

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,9 +10,10 @@ on:
 jobs:
 
   publish-charm:
-    if: github.repository_owner == 'canonical'
     name: Publish Charm
     runs-on: ubuntu-latest
+    # Only publish to charmhub if we are pushing to a special branch or running PRs from something named `branch/*`
+    if: ((github.event_name == 'push') ||  (startsWith( github.head_ref, 'branch/' ))) && github.repository_owner == 'canonical'
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,21 +9,6 @@ on:
 
 jobs:
 
-  lib-check:
-    name: Check libraries
-    runs-on: ubuntu-latest
-    if: github.repository_owner == 'canonical'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Check libs
-        uses: canonical/charming-actions/check-libraries@1.0.3
-        with:
-          credentials: "${{ secrets.charmcraft-credentials }}"
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-
   publish-charm:
     name: Publish Charm
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,11 +9,26 @@ on:
 
 jobs:
 
+  lib-check:
+    name: Check libraries
+    runs-on: ubuntu-latest
+    if: (github.repository_owner == 'canonical') && (github.event.pull_request.merged == true)
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Check libs
+        uses: canonical/charming-actions/check-libraries@1.0.3
+        with:
+          credentials: "${{ secrets.charmcraft-credentials }}"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
   publish-charm:
     name: Publish Charm
     runs-on: ubuntu-latest
     # Only publish to charmhub if we are pushing to a special branch or running PRs from something named `branch/*`
-    if: ((github.event_name == 'push') ||  (startsWith( github.head_ref, 'branch/' ))) && github.repository_owner == 'canonical'
+    if: ((github.event_name == 'push') ||  (startsWith( github.head_ref, 'branch/' ))) && (github.repository_owner == 'canonical) && (github.event.pull_request.merged == true)'
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -29,6 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     # Only publish to charmhub if we are pushing to a special branch or running PRs from something named `branch/*`
     if: ((github.event_name == 'push') ||  (startsWith( github.head_ref, 'branch/' ))) && (github.repository_owner == 'canonical') && (github.event.pull_request.merged == true)
+    needs: lib-check
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -28,7 +28,7 @@ jobs:
     name: Publish Charm
     runs-on: ubuntu-latest
     # Only publish to charmhub if we are pushing to a special branch or running PRs from something named `branch/*`
-    if: ((github.event_name == 'push') ||  (startsWith( github.head_ref, 'branch/' ))) && (github.repository_owner == 'canonical) && (github.event.pull_request.merged == true)'
+    if: ((github.event_name == 'push') ||  (startsWith( github.head_ref, 'branch/' ))) && (github.repository_owner == 'canonical') && (github.event.pull_request.merged == true)
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,7 +12,7 @@ jobs:
   lib-check:
     name: Check libraries
     runs-on: ubuntu-latest
-    if: (github.repository_owner == 'canonical') && (github.event.pull_request.merged == true)
+    if: github.repository_owner == 'canonical'
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -27,7 +27,7 @@ jobs:
   publish-charm:
     name: Publish Charm
     runs-on: ubuntu-latest
-    if: (github.repository_owner == 'canonical') && (github.event.pull_request.merged == true)
+    if: github.repository_owner == 'canonical'
     needs: lib-check
     steps:
       - name: Checkout

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,6 +10,7 @@ on:
 jobs:
 
   publish-charm:
+    if: github.repository_owner == 'canonical'
     name: Publish Charm
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,7 +12,7 @@ jobs:
   publish-charm:
     name: Publish Charm
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'canonical'
+    if: github.actor == 'canonical'
     needs: lib-check
     steps:
       - name: Checkout

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -27,8 +27,7 @@ jobs:
   publish-charm:
     name: Publish Charm
     runs-on: ubuntu-latest
-    # Only publish to charmhub if we are pushing to a special branch or running PRs from something named `branch/*`
-    if: ((github.event_name == 'push') ||  (startsWith( github.head_ref, 'branch/' ))) && (github.repository_owner == 'canonical') && (github.event.pull_request.merged == true)
+    if: (github.repository_owner == 'canonical') && (github.event.pull_request.merged == true)
     needs: lib-check
     steps:
       - name: Checkout


### PR DESCRIPTION
Set CI to only run publish charm action if github repo owner is canonical.