### PR TITLE
Observe leader elected

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 build/
 __pycache__/
 .tox
+.idea

--- a/src/charm.py
+++ b/src/charm.py
@@ -53,6 +53,7 @@ class Operator(CharmBase):
             self.on.config_changed,
             self.on.install,
             self.on.upgrade_charm,
+            self.on.leader_elected,
             self.on["object-storage"].relation_changed,
             self.on["object-storage"].relation_joined,
         ]:
@@ -155,7 +156,7 @@ class Operator(CharmBase):
     def _check_leader(self):
         if not self.unit.is_leader():
             self.log.info("Not a leader, skipping set_pod_spec")
-            raise CheckFailed("", ActiveStatus)
+            raise CheckFailed("Waiting for leadership", WaitingStatus)
 
     def _get_interfaces(self):
         try:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -19,7 +19,7 @@ def harness():
 
 def test_not_leader(harness):
     harness.begin_with_initial_hooks()
-    assert harness.charm.model.unit.status == ActiveStatus("")
+    assert harness.charm.model.unit.status == WaitingStatus("Waiting for leadership")
 
 
 def test_missing_image(harness):


### PR DESCRIPTION
This PR standardizes handling the status when the unit is not leader and adds `leader-elected` to observed events.