### PR TITLE
fix: removes securityContext from podspec

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -114,14 +114,6 @@ class Operator(CharmBase):
                             "emptyDir": {},
                         },
                     ],
-                    "kubernetes": {
-                        "securityContext": {
-                            "runAsNonRoot": False,
-                            "privileged": True,
-                            "readOnlyRootFilesystem": False,
-                            # "runAsUser":1000,
-                        },
-                    },
                 }
             ],
             "kubernetesResources": {


### PR DESCRIPTION
The securityContext on each charm is allowing containers to run
in privileged mode, which is not always desirable as we would be
granting unrestricted access to the OS. This securityContext was
also setting up runAsNonRoot and readOnlyRootFilesystem to false,
which are not needed.

related to canonical/minio-operator#69
backport of changes from future version