### PR TITLE
fix: set minimum size requirements to 1G (default)

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -27,4 +27,3 @@ storage:
   minio-data:
     type: filesystem
     location: /data
-    minimum-size: 10G

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -27,3 +27,4 @@ storage:
   minio-data:
     type: filesystem
     location: /data
+    minimum-size: 1G


### PR DESCRIPTION
https://github.com/canonical/minio-operator/issues/78

Summary of changes:
- Removed minimum size requirements from metadata.yaml