### PR TITLE
feat: localize SDI schemas

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -17,8 +17,33 @@ resources:
 provides:
   object-storage:
     interface: object-storage
-    schema: https://raw.githubusercontent.com/canonical/operator-schemas/master/object-storage.yaml
+    schema:
+      v1:
+        provides:
+          type: object
+          properties:
+            access-key:
+              type: string
+            namespace:
+              type:
+              - string
+              - 'null'
+            port:
+              type: number
+            secret-key:
+              type: string
+            secure:
+              type: boolean
+            service:
+              type: string
+          required:
+          - access-key
+          - port
+          - secret-key
+          - secure
+          - service
     versions: [v1]
+    __schema_source: https://raw.githubusercontent.com/canonical/operator-schemas/master/object-storage.yaml
   metrics-endpoint:
     interface: prometheus_scrape
   grafana-dashboard:


### PR DESCRIPTION
This vendors all remotely defined serialized-data-interface schemas, embedding them in the respective metadata.yaml(s) rather than storing them as a remote link.  This is to enable offline deployment of the charms, as described in [jira](https://warthogs.atlassian.net/browse/KF-727?atlOrigin=eyJpIjoiN2JjZTdlMGYxNDQ3NDdlYzljZDQxNDQ1MTk0OTdkNTEiLCJwIjoiaiJ9).