### PR TITLE
Revert "fix: set minimum size requirement to 1G", set minimum to 10G(#117)

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -52,4 +52,4 @@ storage:
   minio-data:
     type: filesystem
     location: /data
-    minimum-size: 1G
+    minimum-size: 10G


### PR DESCRIPTION


This reverts commit 981ad49ad356efffc454f8fe8abb69d5752d78b9, which solved #78.   We have reverted this because it causes trouble with the upgrade path of the charm. juju will not let you refresh a charm if the storage minimum size has changed between revisions. Because of this, we'll leave the larger minimum storage size in order to preserve the upgrade path