### PR TITLE
fix: explicitly apply minio-service with name

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -22,6 +22,7 @@ from serialized_data_interface import NoCompatibleVersions, NoVersionsListed, ge
 # See https://github.com/kubeflow/pipelines/issues/9689 for more information
 MINIO_SERVICE = "minio-service"
 
+
 class Operator(CharmBase):
     _stored = StoredState()
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -17,6 +17,10 @@ from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
 from serialized_data_interface import NoCompatibleVersions, NoVersionsListed, get_interfaces
 
+# The name of the minio service is hardcoded in the
+# object store source code of pipelines as "minio-service"
+# See https://github.com/kubeflow/pipelines/issues/9689 for more information
+MINIO_SERVICE = "minio-service"
 
 class Operator(CharmBase):
     _stored = StoredState()
@@ -121,7 +125,29 @@ class Operator(CharmBase):
                             }.items()
                         },
                     },
-                ]
+                ],
+                "services": [
+                    {
+                        "name": MINIO_SERVICE,
+                        "spec": {
+                            "selector": {"app.kubernetes.io/name": self.model.app.name},
+                            "ports": [
+                                {
+                                    "name": "minio",
+                                    "port": int(self.model.config["port"]),
+                                    "protocol": "TCP",
+                                    "targetPort": int(self.model.config["port"]),
+                                },
+                                {
+                                    "name": "console",
+                                    "port": int(self.model.config["console-port"]),
+                                    "protocol": "TCP",
+                                    "targetPort": int(self.model.config["console-port"]),
+                                },
+                            ],
+                        },
+                    },
+                ],
             },
         }
 
@@ -165,7 +191,7 @@ class Operator(CharmBase):
                     "port": self.model.config["port"],
                     "secret-key": secret_key,
                     "secure": False,
-                    "service": self.model.app.name,
+                    "service": MINIO_SERVICE,
                 }
             )
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -9,7 +9,7 @@ import yaml
 from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 from ops.testing import Harness
 
-from charm import Operator
+from charm import MINIO_SERVICE, Operator
 
 
 @pytest.fixture
@@ -119,7 +119,7 @@ def test_main_with_relation(harness):
     assert data["port"] == 9000
     assert data["secure"] is False
     assert len(data["secret-key"]) == 30
-    assert data["service"] == "minio"
+    assert data["service"] == MINIO_SERVICE
 
 
 def test_main_with_manual_secret(harness):
@@ -150,7 +150,7 @@ def test_main_with_manual_secret(harness):
         "port": 9000,
         "secret-key": "test-key",
         "secure": False,
-        "service": "minio",
+        "service": MINIO_SERVICE,
     }
     assert harness.charm.model.unit.status == ActiveStatus("")
 


### PR DESCRIPTION
The upstream pipelines project hardcodes the name of the object storage service to minio-service. The current implementation sets the service to just minio, which collides with what pipelines expect. This PR ensures the Service is created with the expected name and ports.

#### Testing

To test this change, you can build and deploy the charm and look for the Service `minio-service`. It should have the following:

* name should be `minio-service` 
* there must be a port with name `minio` and targetPort:9000
* there must be a port with name `console` and targetPort:9001
* the selector must be `app.kubernetes.io/name: minio`

These are the logs we are trying to avoid with the changes in this PR:

```
failed to execute component: failed to upload output artifact "output_dataset_one" to remote storage URI "minio://mlpipeline/v2/artifacts/tutorial-data-passing/731d5ddd-7b18-49ce-9c31-e72ee1b5b252/preprocess/output_dataset_one": uploadFile(): unable to complete copying "/minio/mlpipeline/v2/artifacts/tutorial-data-passing/731d5ddd-7b18-49ce-9c31-e72ee1b5b252/preprocess/output_dataset_one" to remote storage "preprocess/output_dataset_one": failed to close Writer for bucket: blob (key "preprocess/output_dataset_one") (code=Unknown): RequestError: send request failed
caused by: Put "http://minio-service.kubeflow:9000/mlpipeline/v2/artifacts/tutorial-data-passing/731d5ddd-7b18-49ce-9c31-e72ee1b5b252/preprocess/output_dataset_one": dial tcp: lookup minio-service.kubeflow on 10.152.183.10:53: no such host
```

Refer to kubeflow/pipelines#9689 for more information