### PR TITLE
Revert "fix: explicitly apply minio-service with name (#151)"

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -17,11 +17,6 @@ from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
 from serialized_data_interface import NoCompatibleVersions, NoVersionsListed, get_interfaces
 
-# The name of the minio service is hardcoded in the
-# object store source code of pipelines as "minio-service"
-# See https://github.com/kubeflow/pipelines/issues/9689 for more information
-MINIO_SERVICE = "minio-service"
-
 
 class Operator(CharmBase):
     _stored = StoredState()
@@ -126,29 +121,7 @@ class Operator(CharmBase):
                             }.items()
                         },
                     },
-                ],
-                "services": [
-                    {
-                        "name": MINIO_SERVICE,
-                        "spec": {
-                            "selector": {"app.kubernetes.io/name": self.model.app.name},
-                            "ports": [
-                                {
-                                    "name": "minio",
-                                    "port": int(self.model.config["port"]),
-                                    "protocol": "TCP",
-                                    "targetPort": int(self.model.config["port"]),
-                                },
-                                {
-                                    "name": "console",
-                                    "port": int(self.model.config["console-port"]),
-                                    "protocol": "TCP",
-                                    "targetPort": int(self.model.config["console-port"]),
-                                },
-                            ],
-                        },
-                    },
-                ],
+                ]
             },
         }
 
@@ -192,7 +165,7 @@ class Operator(CharmBase):
                     "port": self.model.config["port"],
                     "secret-key": secret_key,
                     "secure": False,
-                    "service": MINIO_SERVICE,
+                    "service": self.model.app.name,
                 }
             )
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -28,6 +28,8 @@ class Operator(CharmBase):
         # Random salt used for hashing config
         self._stored.set_default(hash_salt=_gen_pass())
 
+        self._minio_service_name = self.app.name
+
         self.image = OCIImageResource(self, "oci-image")
 
         self.prometheus_provider = MetricsEndpointProvider(
@@ -165,7 +167,7 @@ class Operator(CharmBase):
                     "port": self.model.config["port"],
                     "secret-key": secret_key,
                     "secure": False,
-                    "service": self.model.app.name,
+                    "service": self._minio_service_name,
                 }
             )
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -9,7 +9,7 @@ import yaml
 from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 from ops.testing import Harness
 
-from charm import MINIO_SERVICE, Operator
+from charm import Operator
 
 
 @pytest.fixture
@@ -119,7 +119,7 @@ def test_main_with_relation(harness):
     assert data["port"] == 9000
     assert data["secure"] is False
     assert len(data["secret-key"]) == 30
-    assert data["service"] == MINIO_SERVICE
+    assert data["service"] == "minio"
 
 
 def test_main_with_manual_secret(harness):
@@ -150,7 +150,7 @@ def test_main_with_manual_secret(harness):
         "port": 9000,
         "secret-key": "test-key",
         "secure": False,
-        "service": MINIO_SERVICE,
+        "service": "minio",
     }
     assert harness.charm.model.unit.status == ActiveStatus("")
 


### PR DESCRIPTION
This reverts commit b99aad877107c8023b981fe06e945a51f2622362 as described in #153.  This fix is instead being moved to the kfp-api charm of [kfp-operators](https://github.com/canonical/kfp-operators).