### PR TITLE
fix: set prometheus authentication variable

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -100,6 +100,9 @@ class Operator(CharmBase):
                         # than an environment variable, but we cannot use that using podspec.
                         # (see https://stackoverflow.com/questions/37317003/restart-pods-when-configmap-updates-in-kubernetes/51421527#51421527)  # noqa E403
                         "configmap-hash": configmap_hash,
+                        # To allow public access without authentication for prometheus
+                        # metrics set environment as follows.
+                        "MINIO_PROMETHEUS_AUTH_TYPE": "public",
                     },
                     "volumeConfig": [
                         {

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -269,6 +269,10 @@ async def test_prometheus_grafana_integration(ops_test: OpsTest):
             assert response_metric["juju_application"] == APP_NAME
             assert response_metric["juju_model"] == ops_test.model_name
 
+            # Assert the unit is available by checking the query result
+            # 1 means available, 0 means unavailable
+            assert response["data"]["result"][0]["value"] == "1"
+
 
 # Helper to retry calling a function over 30 seconds or 5 attempts
 retry_for_5_attempts = Retrying(

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -270,8 +270,10 @@ async def test_prometheus_grafana_integration(ops_test: OpsTest):
             assert response_metric["juju_model"] == ops_test.model_name
 
             # Assert the unit is available by checking the query result
+            # The data is presented as a list [1707357912.349, '1'], where the
+            # first value is a timestamp and the second value is the state of the unit
             # 1 means available, 0 means unavailable
-            assert response["data"]["result"][0]["value"] == "1"
+            assert response["data"]["result"][0]["value"][1] == "1"
 
 
 # Helper to retry calling a function over 30 seconds or 5 attempts


### PR DESCRIPTION
This variable allows public access without authentication for prometheus metrics.

Part of canonical/bundle-kubeflow#564

#### Testing
Please refer to the steps to reproduce in [this comment](https://github.com/canonical/bundle-kubeflow/issues/564#issuecomment-1925538870), just deploying this app. After deploying this app and cos-lite, relations and dependencies, and waiting a couple minutes (10 min) none of the alerts should fire (for this app only).

#### TODO
- [x] refactor integration `test case test_prometheus_grafana_integration`
- [ ] create a backport PR for `track/ckf-1.8`