### PR TITLE
fix: set prometheus authentication variable (#157)

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -100,6 +100,9 @@ class Operator(CharmBase):
                         # than an environment variable, but we cannot use that using podspec.
                         # (see https://stackoverflow.com/questions/37317003/restart-pods-when-configmap-updates-in-kubernetes/51421527#51421527)  # noqa E403
                         "configmap-hash": configmap_hash,
+                        # To allow public access without authentication for prometheus
+                        # metrics set environment as follows.
+                        "MINIO_PROMETHEUS_AUTH_TYPE": "public",
                     },
                     "volumeConfig": [
                         {

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -269,6 +269,12 @@ async def test_prometheus_grafana_integration(ops_test: OpsTest):
             assert response_metric["juju_application"] == APP_NAME
             assert response_metric["juju_model"] == ops_test.model_name
 
+            # Assert the unit is available by checking the query result
+            # The data is presented as a list [1707357912.349, '1'], where the
+            # first value is a timestamp and the second value is the state of the unit
+            # 1 means available, 0 means unavailable
+            assert response["data"]["result"][0]["value"][1] == "1"
+
 
 # Helper to retry calling a function over 30 seconds or 5 attempts
 retry_for_5_attempts = Retrying(


### PR DESCRIPTION
* fix: set prometheus authentication variable

This variable allows public access without authentication for prometheus metrics.

Part of canonical/bundle-kubeflow#564

* tests: add an assertion for checking unit is available

The test_prometheus_grafana_integration test case was doing queries to prometheus and checking the request returned successfully and that the application name and model was listed correctly. To make this test case more accurately, we can add an assertion that also checks that the unit is available, this way we avoid issues like the one described in canonical/bundle-kubeflow#564.

Part of canonical/bundle-kubeflow#564