### PR TITLE
fix: Fix grafana dashboard

### DIFF
--- a/src/grafana_dashboards/minio-overview_rev13.json.tmpl
+++ b/src/grafana_dashboards/minio-overview_rev13.json.tmpl
@@ -2449,6 +2449,7 @@
   "schemaVersion": 30,
   "style": "dark",
   "tags": [
+    "ckf",
     "minio"
   ],
   "templating": {

--- a/src/grafana_dashboards/minio-overview_rev13.json.tmpl
+++ b/src/grafana_dashboards/minio-overview_rev13.json.tmpl
@@ -284,7 +284,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "topk(1, sum(minio_cluster_capacity_usable_free_bytes{}) by (instance))",
+          "expr": "topk(1, sum(minio_node_disk_free_bytes{}) by (instance))",
           "format": "time_series",
           "instant": false,
           "interval": "1m",

--- a/src/grafana_dashboards/minio-overview_rev13.json.tmpl
+++ b/src/grafana_dashboards/minio-overview_rev13.json.tmpl
@@ -136,7 +136,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "time() - max(minio_node_process_starttime_seconds{job=\"$scrape_jobs\"})",
+          "expr": "time() - max(minio_node_process_starttime_seconds{})",
           "format": "time_series",
           "instant": true,
           "interval": "",
@@ -211,7 +211,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum by (instance) (minio_s3_traffic_received_bytes{job=\"$scrape_jobs\"})",
+          "expr": "sum by (instance) (minio_s3_traffic_received_bytes{})",
           "format": "table",
           "hide": false,
           "instant": false,
@@ -284,7 +284,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "topk(1, sum(minio_cluster_capacity_usable_free_bytes{job=\"$scrape_jobs\"}) by (instance))",
+          "expr": "topk(1, sum(minio_cluster_capacity_usable_free_bytes{}) by (instance))",
           "format": "time_series",
           "instant": false,
           "interval": "1m",
@@ -342,7 +342,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(minio_bucket_usage_total_bytes{job=\"$scrape_jobs\"}) by (instance)",
+          "expr": "sum(minio_bucket_usage_total_bytes{}) by (instance)",
           "interval": "",
           "legendFormat": "Used Capacity",
           "refId": "A"
@@ -437,7 +437,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "max by (range) (minio_bucket_objects_size_distribution{job=\"$scrape_jobs\"})",
+          "expr": "max by (range) (minio_bucket_objects_size_distribution{})",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -515,7 +515,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum (minio_node_file_descriptor_open_total{job=\"$scrape_jobs\"})",
+          "expr": "sum (minio_node_file_descriptor_open_total{})",
           "format": "table",
           "hide": false,
           "instant": false,
@@ -591,7 +591,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum by (instance) (minio_s3_traffic_sent_bytes{job=\"$scrape_jobs\"})",
+          "expr": "sum by (instance) (minio_s3_traffic_sent_bytes{})",
           "format": "table",
           "hide": false,
           "instant": false,
@@ -671,7 +671,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum without (server,instance) (minio_node_go_routine_total{job=\"$scrape_jobs\"})",
+          "expr": "sum without (server,instance) (minio_node_go_routine_total{})",
           "format": "table",
           "hide": false,
           "instant": false,
@@ -751,7 +751,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "minio_cluster_nodes_online_total{job=\"$scrape_jobs\"}",
+          "expr": "minio_cluster_nodes_online_total{}",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -831,7 +831,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "minio_cluster_disk_online_total{job=\"$scrape_jobs\"}",
+          "expr": "minio_cluster_disk_online_total{}",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -914,7 +914,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "count(count by (bucket) (minio_bucket_usage_total_bytes{job=\"$scrape_jobs\"}))",
+          "expr": "count(count by (bucket) (minio_bucket_usage_total_bytes{}))",
           "format": "time_series",
           "instant": false,
           "interval": "1m",
@@ -972,7 +972,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum by (server) (rate(minio_s3_traffic_received_bytes{job=\"$scrape_jobs\"}[$__rate_interval]))",
+          "expr": "sum by (server) (rate(minio_s3_traffic_received_bytes{}[$__rate_interval]))",
           "interval": "1m",
           "intervalFactor": 2,
           "legendFormat": "Data Received [{{server}}]",
@@ -1068,7 +1068,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum by (server) (rate(minio_s3_traffic_sent_bytes{job=\"$scrape_jobs\"}[$__rate_interval]))",
+          "expr": "sum by (server) (rate(minio_s3_traffic_sent_bytes{}[$__rate_interval]))",
           "interval": "1m",
           "intervalFactor": 2,
           "legendFormat": "Data Sent [{{server}}]",
@@ -1181,7 +1181,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "minio_cluster_nodes_offline_total{job=\"$scrape_jobs\"}",
+          "expr": "minio_cluster_nodes_offline_total{}",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -1261,7 +1261,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "minio_cluster_disk_offline_total{job=\"$scrape_jobs\"}",
+          "expr": "minio_cluster_disk_offline_total{}",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -1344,7 +1344,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "topk(1, sum(minio_bucket_usage_object_total{job=\"$scrape_jobs\"}) by (instance))",
+          "expr": "topk(1, sum(minio_bucket_usage_object_total{}) by (instance))",
           "format": "time_series",
           "instant": false,
           "interval": "1m",
@@ -1408,7 +1408,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "minio_heal_time_last_activity_nano_seconds{job=\"$scrape_jobs\"}",
+          "expr": "minio_heal_time_last_activity_nano_seconds{}",
           "format": "time_series",
           "instant": true,
           "interval": "",
@@ -1476,7 +1476,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "minio_usage_last_activity_nano_seconds{job=\"$scrape_jobs\"}",
+          "expr": "minio_usage_last_activity_nano_seconds{}",
           "format": "time_series",
           "instant": true,
           "interval": "",
@@ -1538,7 +1538,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum by (server,api) (increase(minio_s3_requests_total{job=\"$scrape_jobs\"}[$__rate_interval]))",
+          "expr": "sum by (server,api) (increase(minio_s3_requests_total{}[$__rate_interval]))",
           "interval": "1m",
           "intervalFactor": 2,
           "legendFormat": "{{server,api}}",
@@ -1634,7 +1634,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum by (server,api) (increase(minio_s3_requests_errors_total{job=\"$scrape_jobs\"}[$__rate_interval]))",
+          "expr": "sum by (server,api) (increase(minio_s3_requests_errors_total{}[$__rate_interval]))",
           "interval": "1m",
           "intervalFactor": 2,
           "legendFormat": "{{server,api}}",
@@ -1740,7 +1740,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "rate(minio_inter_node_traffic_sent_bytes{job=\"$scrape_jobs\"}[$__rate_interval])",
+          "expr": "rate(minio_inter_node_traffic_sent_bytes{}[$__rate_interval])",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -1751,7 +1751,7 @@
         },
         {
           "exemplar": true,
-          "expr": "rate(minio_inter_node_traffic_received_bytes{job=\"$scrape_jobs\"}[$__rate_interval])",
+          "expr": "rate(minio_inter_node_traffic_received_bytes{}[$__rate_interval])",
           "interval": "",
           "legendFormat": "Internode Bytes Sent [{{server}}]",
           "refId": "B"
@@ -1843,14 +1843,14 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum by (instance) (minio_heal_objects_heal_total{job=\"$scrape_jobs\"})",
+          "expr": "sum by (instance) (minio_heal_objects_heal_total{})",
           "interval": "",
           "legendFormat": "Objects healed in current self heal run",
           "refId": "A"
         },
         {
           "exemplar": true,
-          "expr": "sum by (instance) (minio_heal_objects_error_total{job=\"$scrape_jobs\"})",
+          "expr": "sum by (instance) (minio_heal_objects_error_total{})",
           "hide": false,
           "interval": "",
           "legendFormat": "Heal errors in current self heal run",
@@ -1858,7 +1858,7 @@
         },
         {
           "exemplar": true,
-          "expr": "sum by (instance) (minio_heal_objects_total{job=\"$scrape_jobs\"}) ",
+          "expr": "sum by (instance) (minio_heal_objects_total{}) ",
           "hide": false,
           "interval": "",
           "legendFormat": "Objects scanned in current self heal run",
@@ -1951,7 +1951,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "rate(minio_node_process_cpu_total_seconds{job=\"$scrape_jobs\"}[$__rate_interval])",
+          "expr": "rate(minio_node_process_cpu_total_seconds{}[$__rate_interval])",
           "interval": "",
           "legendFormat": "CPU Usage Rate [{{server}}]",
           "refId": "A"
@@ -2043,7 +2043,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "minio_node_process_resident_memory_bytes{job=\"$scrape_jobs\"}",
+          "expr": "minio_node_process_resident_memory_bytes{}",
           "interval": "",
           "legendFormat": "Memory Used [{{server}}]",
           "refId": "A"
@@ -2135,7 +2135,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "minio_node_disk_used_bytes{job=\"$scrape_jobs\"}",
+          "expr": "minio_node_disk_used_bytes{}",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -2229,7 +2229,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "minio_cluster_disk_free_inodes{job=\"$scrape_jobs\"}",
+          "expr": "minio_cluster_disk_free_inodes{}",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -2336,7 +2336,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "rate(minio_node_syscall_read_total{job=\"$scrape_jobs\"}[$__rate_interval])",
+          "expr": "rate(minio_node_syscall_read_total{}[$__rate_interval])",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -2347,7 +2347,7 @@
         },
         {
           "exemplar": true,
-          "expr": "rate(minio_node_syscall_write_total{job=\"$scrape_jobs\"}[$__rate_interval])",
+          "expr": "rate(minio_node_syscall_write_total{}[$__rate_interval])",
           "interval": "",
           "legendFormat": "Write Syscalls [{{server}}]",
           "refId": "B"
@@ -2453,7 +2453,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "minio_node_file_descriptor_open_total{job=\"$scrape_jobs\"}",
+          "expr": "minio_node_file_descriptor_open_total{}",
           "interval": "",
           "legendFormat": "Open FDs [{{server}}]",
           "refId": "B"
@@ -2546,7 +2546,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "rate(minio_node_io_rchar_bytes{job=\"$scrape_jobs\"}[$__rate_interval])",
+          "expr": "rate(minio_node_io_rchar_bytes{}[$__rate_interval])",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -2555,7 +2555,7 @@
         },
         {
           "exemplar": true,
-          "expr": "rate(minio_node_io_wchar_bytes{job=\"$scrape_jobs\"}[$__rate_interval])",
+          "expr": "rate(minio_node_io_wchar_bytes{}[$__rate_interval])",
           "interval": "",
           "legendFormat": "Node WChar [{{server}}]",
           "refId": "B"

--- a/src/grafana_dashboards/minio-overview_rev13.json.tmpl
+++ b/src/grafana_dashboards/minio-overview_rev13.json.tmpl
@@ -771,86 +771,6 @@
     {
       "cacheTimeout": null,
       "datasource": "${prometheusds}",
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "mappings": [
-            {
-              "options": {
-                "match": "null",
-                "result": {
-                  "text": "N/A"
-                }
-              },
-              "type": "special"
-            }
-          ],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 2,
-        "w": 3,
-        "x": 3,
-        "y": 6
-      },
-      "id": 9,
-      "interval": null,
-      "links": [],
-      "maxDataPoints": 100,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "mean"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "text": {},
-        "textMode": "auto"
-      },
-      "pluginVersion": "8.0.6",
-      "targets": [
-        {
-          "exemplar": true,
-          "expr": "minio_cluster_disk_online_total{}",
-          "format": "table",
-          "hide": false,
-          "instant": true,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "Total online disks in MinIO Cluster",
-          "metric": "process_start_time_seconds",
-          "refId": "A",
-          "step": 60
-        }
-      ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Total Online Disks",
-      "type": "stat"
-    },
-    {
-      "cacheTimeout": null,
-      "datasource": "${prometheusds}",
       "fieldConfig": {
         "defaults": {
           "mappings": [
@@ -1201,86 +1121,6 @@
     {
       "cacheTimeout": null,
       "datasource": "${prometheusds}",
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "mappings": [
-            {
-              "options": {
-                "match": "null",
-                "result": {
-                  "text": "N/A"
-                }
-              },
-              "type": "special"
-            }
-          ],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 2,
-        "w": 3,
-        "x": 3,
-        "y": 8
-      },
-      "id": 78,
-      "interval": null,
-      "links": [],
-      "maxDataPoints": 100,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "mean"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "text": {},
-        "textMode": "auto"
-      },
-      "pluginVersion": "8.0.6",
-      "targets": [
-        {
-          "exemplar": true,
-          "expr": "minio_cluster_disk_offline_total{}",
-          "format": "table",
-          "hide": false,
-          "instant": true,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "",
-          "metric": "process_start_time_seconds",
-          "refId": "A",
-          "step": 60
-        }
-      ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Total Offline Disks",
-      "type": "stat"
-    },
-    {
-      "cacheTimeout": null,
-      "datasource": "${prometheusds}",
       "fieldConfig": {
         "defaults": {
           "mappings": [
@@ -1451,7 +1291,7 @@
         "h": 2,
         "w": 3,
         "x": 3,
-        "y": 10
+        "y": 6
       },
       "id": 81,
       "interval": null,
@@ -1850,7 +1690,7 @@
         },
         {
           "exemplar": true,
-          "expr": "sum by (instance) (minio_heal_objects_error_total{})",
+          "expr": "sum by (instance) (minio_heal_objects_errors_total{})",
           "hide": false,
           "interval": "",
           "legendFormat": "Heal errors in current self heal run",

--- a/src/grafana_dashboards/minio-overview_rev13.json.tmpl
+++ b/src/grafana_dashboards/minio-overview_rev13.json.tmpl
@@ -284,7 +284,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "topk(1, sum(minio_node_disk_free_bytes{}) by (instance))",
+          "expr": "topk(1, sum(minio_cluster_capacity_usable_free_bytes{}) by (instance))",
           "format": "time_series",
           "instant": false,
           "interval": "1m",
@@ -771,86 +771,6 @@
     {
       "cacheTimeout": null,
       "datasource": "${prometheusds}",
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "mappings": [
-            {
-              "options": {
-                "match": "null",
-                "result": {
-                  "text": "N/A"
-                }
-              },
-              "type": "special"
-            }
-          ],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 2,
-        "w": 3,
-        "x": 3,
-        "y": 6
-      },
-      "id": 9,
-      "interval": null,
-      "links": [],
-      "maxDataPoints": 100,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "mean"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "text": {},
-        "textMode": "auto"
-      },
-      "pluginVersion": "8.0.6",
-      "targets": [
-        {
-          "exemplar": true,
-          "expr": "minio_cluster_drive_online_total{job=\"$scrape_jobs\"}",
-          "format": "table",
-          "hide": false,
-          "instant": true,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "Total online disks in MinIO Cluster",
-          "metric": "process_start_time_seconds",
-          "refId": "A",
-          "step": 60
-        }
-      ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Total Online Disks",
-      "type": "stat"
-    },
-    {
-      "cacheTimeout": null,
-      "datasource": "${prometheusds}",
       "fieldConfig": {
         "defaults": {
           "mappings": [
@@ -1155,86 +1075,6 @@
       "gridPos": {
         "h": 2,
         "w": 3,
-        "x": 3,
-        "y": 8
-      },
-      "id": 78,
-      "interval": null,
-      "links": [],
-      "maxDataPoints": 100,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "mean"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "text": {},
-        "textMode": "auto"
-      },
-      "pluginVersion": "8.0.6",
-      "targets": [
-        {
-          "exemplar": true,
-          "expr": "minio_cluster_drive_offline_total{job=\"$scrape_jobs\"}",
-          "format": "table",
-          "hide": false,
-          "instant": true,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "",
-          "metric": "process_start_time_seconds",
-          "refId": "A",
-          "step": 60
-        }
-      ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Total Offline Disks",
-      "type": "stat"
-    },
-    {
-      "cacheTimeout": null,
-      "datasource": "${prometheusds}",
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "mappings": [
-            {
-              "options": {
-                "match": "null",
-                "result": {
-                  "text": "N/A"
-                }
-              },
-              "type": "special"
-            }
-          ],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 2,
-        "w": 3,
         "x": 0,
         "y": 8
       },
@@ -1451,7 +1291,7 @@
         "h": 2,
         "w": 3,
         "x": 3,
-        "y": 10
+        "y": 6
       },
       "id": 81,
       "interval": null,

--- a/src/grafana_dashboards/minio-overview_rev13.json.tmpl
+++ b/src/grafana_dashboards/minio-overview_rev13.json.tmpl
@@ -284,7 +284,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "topk(1, sum(minio_cluster_capacity_usable_free_bytes{}) by (instance))",
+          "expr": "topk(1, sum(minio_node_disk_free_bytes{}) by (instance))",
           "format": "time_series",
           "instant": false,
           "interval": "1m",
@@ -771,6 +771,86 @@
     {
       "cacheTimeout": null,
       "datasource": "${prometheusds}",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 3,
+        "x": 3,
+        "y": 6
+      },
+      "id": 9,
+      "interval": null,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.0.6",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "minio_cluster_drive_online_total{job=\"$scrape_jobs\"}",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Total online disks in MinIO Cluster",
+          "metric": "process_start_time_seconds",
+          "refId": "A",
+          "step": 60
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Total Online Disks",
+      "type": "stat"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": "${prometheusds}",
       "fieldConfig": {
         "defaults": {
           "mappings": [
@@ -1075,6 +1155,86 @@
       "gridPos": {
         "h": 2,
         "w": 3,
+        "x": 3,
+        "y": 8
+      },
+      "id": 78,
+      "interval": null,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.0.6",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "minio_cluster_drive_offline_total{job=\"$scrape_jobs\"}",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "metric": "process_start_time_seconds",
+          "refId": "A",
+          "step": 60
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Total Offline Disks",
+      "type": "stat"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": "${prometheusds}",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 3,
         "x": 0,
         "y": 8
       },
@@ -1291,7 +1451,7 @@
         "h": 2,
         "w": 3,
         "x": 3,
-        "y": 6
+        "y": 10
       },
       "id": 81,
       "interval": null,


### PR DESCRIPTION
This PR is part of https://github.com/canonical/bundle-kubeflow/issues/856.
It fixes the dashboard by:
* Removing `job=scrape_jobs` label from dashboard fields
* Removing panels using metrics that are not provided by the minio workload.
* Reorder panels for filling gaps created by removed panels.

On top of that, it adds a `ckf` tag to the dashboard.

Ref canonical/bundle-kubeflow#856