### PR TITLE
ci: use juju 3.4/stable instead of 3.5/stable

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -53,7 +53,7 @@ jobs:
           channel: 1.29-strict/stable
           microk8s-addons: "dns storage rbac metallb:10.64.140.43-10.64.140.49"
           charmcraft-channel: latest/candidate
-          juju-channel: 3.5/stable
+          juju-channel: 3.4/stable
 
       - name: Build and test
         run: |


### PR DESCRIPTION
Part of canonical/bundle-kubeflow#944