### PR TITLE
Set status to Blocked when secret-key is shorter than 8 characters long

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -17,7 +17,7 @@ options:
   secret-key:
     type: string
     default: ''
-    description: Secret key
+    description: Secret key. Must be at least 8 characters long. If not provided, a random key will be used.
   mode:
     type: string
     default: 'server'

--- a/src/charm.py
+++ b/src/charm.py
@@ -70,6 +70,13 @@ class Operator(CharmBase):
             return
 
         secret_key = self._get_secret_key()
+
+        if len(secret_key) < 8:
+            self.model.unit.status = BlockedStatus(
+                "The `secret-key` config value must be at least 8 characters long."
+            )
+            return
+
         self._send_info(interfaces, secret_key)
 
         configmap_hash = self._generate_config_hash()


### PR DESCRIPTION
Closes https://github.com/canonical/minio-operator/issues/137.

This PR adds an additional check in the charm.py file to ensure that the `secret-key` is at least 8 characters long. If it isn't, the charm's status changes to blocked with an appropriate message.

The minimum size of 8 characters seems to be hard-coded in [this line](https://github.com/minio/minio/blob/4e67a4027e3c9ba7f294bd71a9000b03c5efad7e/internal/auth/credentials.go#L45).