### PR TITLE
backport(fix): block when secret-key is too short from #178

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -17,7 +17,7 @@ options:
   secret-key:
     type: string
     default: ''
-    description: Secret key
+    description: Secret key. Must be at least 8 characters long. If not provided, a random key will be used.
   mode:
     type: string
     default: 'server'

--- a/src/charm.py
+++ b/src/charm.py
@@ -70,6 +70,13 @@ class Operator(CharmBase):
             return
 
         secret_key = self._get_secret_key()
+
+        if len(secret_key) < 8:
+            self.model.unit.status = BlockedStatus(
+                "The `secret-key` config value must be at least 8 characters long."
+            )
+            return
+
         self._send_info(interfaces, secret_key)
 
         configmap_hash = self._generate_config_hash()


### PR DESCRIPTION
Ensure that the secret-key is at least 8 characters long

Fix #137 