### PR TITLE
ci: bump juju, dependencies + pin pip

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -58,8 +58,8 @@ jobs:
           provider: microk8s
           channel: 1.29-strict/stable
           microk8s-addons: "dns storage rbac metallb:10.64.140.43-10.64.140.49"
-          charmcraft-channel: latest/candidate
-          juju-channel: 3.4/stable
+          charmcraft-channel: 3.x/stable
+          juju-channel: 3.6/stable
 
       - name: Build and test
         run: |

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -91,4 +91,4 @@ jobs:
           charm-path: ${{ matrix.charm-path }}
           channel: ${{ steps.parse-inputs.outputs.destination_channel }}
           tag-prefix: ${{ steps.parse-inputs.outputs.tag_prefix }}
-          charmcraft-channel: latest/candidate
+          charmcraft-channel: 3.x/stable

--- a/requirements-fmt.txt
+++ b/requirements-fmt.txt
@@ -4,21 +4,21 @@
 #
 #    pip-compile requirements-fmt.in
 #
-black==23.7.0
+black==24.8.0
     # via -r requirements-fmt.in
-click==8.1.6
+click==8.1.7
     # via black
-isort==5.12.0
+isort==5.13.2
     # via -r requirements-fmt.in
 mypy-extensions==1.0.0
     # via black
-packaging==23.1
+packaging==24.2
     # via black
-pathspec==0.11.2
+pathspec==0.12.1
     # via black
-platformdirs==3.10.0
+platformdirs==4.3.6
     # via black
-tomli==2.0.1
+tomli==2.2.1
     # via black
-typing-extensions==4.7.1
+typing-extensions==4.12.2
     # via black

--- a/requirements-integration.txt
+++ b/requirements-integration.txt
@@ -4,26 +4,28 @@
 #
 #    pip-compile requirements-integration.in
 #
-anyio==4.4.0
+anyio==4.5.2
     # via httpx
-asttokens==2.4.0
+asttokens==3.0.0
     # via stack-data
-attrs==23.1.0
+attrs==24.2.0
     # via
     #   jsonschema
     #   outcome
     #   trio
 backcall==0.2.0
     # via ipython
-bcrypt==4.0.1
+backports-strenum==1.3.1
+    # via juju
+bcrypt==4.2.1
     # via paramiko
-blinker==1.6.2
+blinker==1.8.2
     # via selenium-wire
 brotli==1.1.0
     # via selenium-wire
-cachetools==5.3.1
+cachetools==5.5.0
     # via google-auth
-certifi==2023.7.22
+certifi==2024.8.30
     # via
     #   httpcore
     #   httpx
@@ -31,15 +33,15 @@ certifi==2023.7.22
     #   requests
     #   selenium
     #   selenium-wire
-cffi==1.15.1
+cffi==1.17.1
     # via
     #   cryptography
     #   pynacl
 charmed-kubeflow-chisme==0.4.3
     # via -r requirements-integration.in
-charset-normalizer==3.2.0
+charset-normalizer==3.4.0
     # via requests
-cryptography==41.0.3
+cryptography==44.0.0
     # via
     #   paramiko
     #   pyopenssl
@@ -49,15 +51,15 @@ decorator==5.1.1
     #   ipython
 deepdiff==6.2.1
     # via charmed-kubeflow-chisme
-exceptiongroup==1.1.3
+exceptiongroup==1.2.2
     # via
     #   anyio
     #   pytest
     #   trio
     #   trio-websocket
-executing==1.2.0
+executing==2.1.0
     # via stack-data
-google-auth==2.17.3
+google-auth==2.36.0
     # via kubernetes
 h11==0.14.0
     # via
@@ -67,56 +69,56 @@ h2==4.1.0
     # via selenium-wire
 hpack==4.0.0
     # via h2
-httpcore==1.0.5
+httpcore==1.0.7
     # via httpx
-httpx==0.27.0
+httpx==0.28.0
     # via lightkube
-hvac==1.2.0
+hvac==2.3.0
     # via juju
 hyperframe==6.0.1
     # via
     #   h2
     #   selenium-wire
-idna==3.4
+idna==3.10
     # via
     #   anyio
     #   httpx
     #   requests
     #   trio
-importlib-resources==6.4.3
+importlib-resources==6.4.5
     # via jsonschema
 iniconfig==2.0.0
     # via pytest
 ipdb==0.13.13
     # via pytest-operator
-ipython==8.12.2
+ipython==8.12.3
     # via ipdb
-jedi==0.19.0
+jedi==0.19.2
     # via ipython
-jinja2==3.1.2
+jinja2==3.1.4
     # via
     #   charmed-kubeflow-chisme
     #   pytest-operator
 jsonschema==4.17.3
     # via serialized-data-interface
-juju==3.2.2
+juju==3.6.0.0
     # via
     #   -r requirements-integration.in
     #   charmed-kubeflow-chisme
     #   pytest-operator
 kaitaistruct==0.10
     # via selenium-wire
-kubernetes==27.2.0
+kubernetes==30.1.0
     # via juju
-lightkube==0.15.3
+lightkube==0.15.5
     # via charmed-kubeflow-chisme
-lightkube-models==1.30.0.8
+lightkube-models==1.31.1.8
     # via lightkube
-macaroonbakery==1.3.1
+macaroonbakery==1.3.4
     # via juju
-markupsafe==2.1.3
+markupsafe==2.1.5
     # via jinja2
-matplotlib-inline==0.1.6
+matplotlib-inline==0.1.7
     # via ipython
 mypy-extensions==1.0.0
     # via typing-inspect
@@ -124,50 +126,50 @@ oauthlib==3.2.2
     # via
     #   kubernetes
     #   requests-oauthlib
-ops==2.15.0
+ops==2.17.1
     # via
     #   charmed-kubeflow-chisme
     #   serialized-data-interface
 ordered-set==4.1.0
     # via deepdiff
-outcome==1.2.0
+outcome==1.3.0.post0
     # via trio
-packaging==23.1
-    # via pytest
-paramiko==2.12.0
+packaging==24.2
+    # via
+    #   juju
+    #   pytest
+paramiko==3.5.0
     # via juju
-parso==0.8.3
+parso==0.8.4
     # via jedi
-pexpect==4.8.0
+pexpect==4.9.0
     # via ipython
 pickleshare==0.7.5
     # via ipython
 pkgutil-resolve-name==1.3.10
     # via jsonschema
-pluggy==1.3.0
+pluggy==1.5.0
     # via pytest
-prompt-toolkit==3.0.39
+prompt-toolkit==3.0.48
     # via ipython
-protobuf==3.20.3
+protobuf==5.29.0
     # via macaroonbakery
 ptyprocess==0.7.0
     # via pexpect
-pure-eval==0.2.2
+pure-eval==0.2.3
     # via stack-data
-pyasn1==0.5.0
+pyasn1==0.6.1
     # via
     #   juju
     #   pyasn1-modules
     #   rsa
     #   selenium-wire
-pyasn1-modules==0.3.0
+pyasn1-modules==0.4.1
     # via google-auth
-pycparser==2.21
+pycparser==2.22
     # via cffi
-pygments==2.16.1
+pygments==2.18.0
     # via ipython
-pyhcl==0.4.5
-    # via hvac
 pymacaroons==0.13.0
     # via macaroonbakery
 pynacl==1.5.0
@@ -175,9 +177,9 @@ pynacl==1.5.0
     #   macaroonbakery
     #   paramiko
     #   pymacaroons
-pyopenssl==23.2.0
+pyopenssl==24.3.0
     # via selenium-wire
-pyparsing==3.1.1
+pyparsing==3.1.4
     # via selenium-wire
 pyrfc3339==1.1
     # via
@@ -189,20 +191,20 @@ pysocks==1.7.1
     # via
     #   selenium-wire
     #   urllib3
-pytest==7.4.2
+pytest==8.3.4
     # via
     #   -r requirements-integration.in
     #   pytest-asyncio
     #   pytest-operator
-pytest-asyncio==0.21.1
+pytest-asyncio==0.21.2
     # via pytest-operator
-pytest-operator==0.29.0
+pytest-operator==0.38.0
     # via -r requirements-integration.in
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via kubernetes
-pytz==2023.3.post1
+pytz==2024.2
     # via pyrfc3339
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
     #   -r requirements-integration.in
     #   juju
@@ -211,7 +213,7 @@ pyyaml==6.0.1
     #   ops
     #   pytest-operator
     #   serialized-data-interface
-requests==2.31.0
+requests==2.32.3
     # via
     #   -r requirements-integration.in
     #   hvac
@@ -219,7 +221,7 @@ requests==2.31.0
     #   macaroonbakery
     #   requests-oauthlib
     #   serialized-data-interface
-requests-oauthlib==1.3.1
+requests-oauthlib==2.0.0
     # via kubernetes
 rsa==4.9
     # via google-auth
@@ -227,7 +229,7 @@ ruamel-yaml==0.18.6
     # via charmed-kubeflow-chisme
 ruamel-yaml-clib==0.2.8
     # via ruamel-yaml
-selenium==4.12.0
+selenium==4.27.1
     # via
     #   -r requirements-integration.in
     #   selenium-wire
@@ -237,67 +239,66 @@ serialized-data-interface==0.7.0
     # via charmed-kubeflow-chisme
 six==1.16.0
     # via
-    #   asttokens
-    #   google-auth
     #   kubernetes
     #   macaroonbakery
-    #   paramiko
     #   pymacaroons
     #   python-dateutil
-sniffio==1.3.0
+sniffio==1.3.1
     # via
     #   anyio
-    #   httpx
     #   trio
 sortedcontainers==2.4.0
     # via trio
-stack-data==0.6.2
+stack-data==0.6.3
     # via ipython
-tenacity==8.2.3
+tenacity==9.0.0
     # via
     #   -r requirements-integration.in
     #   charmed-kubeflow-chisme
-tomli==2.0.1
+tomli==2.2.1
     # via
     #   ipdb
     #   pytest
 toposort==1.10
     # via juju
-traitlets==5.9.0
+traitlets==5.14.3
     # via
     #   ipython
     #   matplotlib-inline
-trio==0.22.2
+trio==0.27.0
     # via
     #   selenium
     #   trio-websocket
-trio-websocket==0.10.4
+trio-websocket==0.11.1
     # via selenium
-typing-extensions==4.7.1
+typing-extensions==4.12.2
     # via
     #   anyio
     #   ipython
+    #   juju
+    #   selenium
     #   typing-inspect
 typing-inspect==0.9.0
     # via juju
-urllib3[socks]==2.0.4
+urllib3[socks]==2.2.3
     # via
     #   kubernetes
     #   requests
     #   selenium
-wcwidth==0.2.6
+wcwidth==0.2.13
     # via prompt-toolkit
-websocket-client==1.6.2
+websocket-client==1.8.0
     # via
     #   kubernetes
     #   ops
-websockets==8.1
+    #   selenium
+websockets==13.1
     # via juju
 wsproto==1.2.0
     # via
     #   selenium-wire
     #   trio-websocket
-zipp==3.20.0
+zipp==3.20.2
     # via importlib-resources
-zstandard==0.21.0
+zstandard==0.23.0
     # via selenium-wire

--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -4,47 +4,47 @@
 #
 #    pip-compile requirements-lint.in
 #
-black==23.7.0
+black==24.8.0
     # via -r requirements-lint.in
-click==8.1.6
+click==8.1.7
     # via black
-codespell==2.2.5
+codespell==2.3.0
     # via -r requirements-lint.in
-flake8==6.0.0
+flake8==7.0.0
     # via
     #   -r requirements-lint.in
     #   flake8-builtins
     #   pep8-naming
     #   pyproject-flake8
-flake8-builtins==2.1.0
+flake8-builtins==2.5.0
     # via -r requirements-lint.in
 flake8-copyright==0.2.4
     # via -r requirements-lint.in
-isort==5.12.0
+isort==5.13.2
     # via -r requirements-lint.in
 mccabe==0.7.0
     # via flake8
 mypy-extensions==1.0.0
     # via black
-packaging==23.1
+packaging==24.2
     # via black
-pathspec==0.11.2
+pathspec==0.12.1
     # via black
-pep8-naming==0.13.3
+pep8-naming==0.14.1
     # via -r requirements-lint.in
-platformdirs==3.10.0
+platformdirs==4.3.6
     # via black
-pycodestyle==2.10.0
+pycodestyle==2.11.1
     # via flake8
-pyflakes==3.0.1
+pyflakes==3.2.0
     # via flake8
-pyproject-flake8==6.0.0.post1
+pyproject-flake8==7.0.0
     # via -r requirements-lint.in
-tomli==2.0.1
+tomli==2.2.1
     # via
     #   black
     #   pyproject-flake8
-typing-extensions==4.7.1
+typing-extensions==4.12.2
     # via black
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements-unit.txt
+++ b/requirements-unit.txt
@@ -4,68 +4,104 @@
 #
 #    pip-compile requirements-unit.in
 #
-attrs==23.1.0
+annotated-types==0.7.0
+    # via pydantic
+anyio==4.5.2
+    # via httpx
+attrs==24.2.0
     # via jsonschema
-certifi==2023.7.22
+certifi==2024.8.30
+    # via
+    #   httpcore
+    #   httpx
+    #   requests
+charset-normalizer==3.4.0
     # via requests
-charset-normalizer==3.2.0
-    # via requests
-cosl==0.0.11
+cosl==0.0.45
     # via -r requirements.in
-coverage==7.3.0
+coverage==7.6.1
     # via -r requirements-unit.in
-exceptiongroup==1.1.2
-    # via pytest
-idna==3.4
-    # via requests
-importlib-resources==6.0.1
+exceptiongroup==1.2.2
+    # via
+    #   anyio
+    #   pytest
+h11==0.14.0
+    # via httpcore
+httpcore==1.0.7
+    # via httpx
+httpx==0.28.0
+    # via lightkube
+idna==3.10
+    # via
+    #   anyio
+    #   httpx
+    #   requests
+importlib-resources==6.4.5
     # via jsonschema
 iniconfig==2.0.0
     # via pytest
 jsonschema==4.17.3
     # via serialized-data-interface
+lightkube==0.15.5
+    # via cosl
+lightkube-models==1.31.1.8
+    # via lightkube
 oci-image==1.0.0
     # via -r requirements.in
-ops==2.14.0
+ops==2.17.1
     # via
     #   -r requirements-unit.in
     #   -r requirements.in
     #   cosl
     #   serialized-data-interface
-packaging==23.1
+packaging==24.2
     # via pytest
 pkgutil-resolve-name==1.3.10
     # via jsonschema
-pluggy==1.2.0
+pluggy==1.5.0
     # via pytest
-pyrsistent==0.19.3
+pydantic==2.10.2
+    # via cosl
+pydantic-core==2.27.1
+    # via pydantic
+pyrsistent==0.20.0
     # via jsonschema
-pytest==7.4.0
+pytest==8.3.4
     # via
     #   -r requirements-unit.in
     #   pytest-lazy-fixture
     #   pytest-mock
 pytest-lazy-fixture==0.6.3
     # via -r requirements-unit.in
-pytest-mock==3.11.1
+pytest-mock==3.14.0
     # via -r requirements-unit.in
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
     #   -r requirements-unit.in
     #   cosl
+    #   lightkube
     #   ops
     #   serialized-data-interface
-requests==2.31.0
+requests==2.32.3
     # via serialized-data-interface
 serialized-data-interface==0.7.0
     # via -r requirements.in
-tomli==2.0.1
-    # via pytest
-typing-extensions==4.11.0
+sniffio==1.3.1
+    # via anyio
+tenacity==9.0.0
     # via cosl
-urllib3==2.0.4
+tomli==2.2.1
+    # via pytest
+typing-extensions==4.12.2
+    # via
+    #   annotated-types
+    #   anyio
+    #   cosl
+    #   pydantic
+    #   pydantic-core
+urllib3==2.2.3
     # via requests
-websocket-client==1.6.1
+websocket-client==1.8.0
     # via ops
-zipp==3.16.2
+zipp==3.20.2
     # via importlib-resources

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,45 +4,81 @@
 #
 #    pip-compile requirements.in
 #
-attrs==23.1.0
+annotated-types==0.7.0
+    # via pydantic
+anyio==4.5.2
+    # via httpx
+attrs==24.2.0
     # via jsonschema
-certifi==2023.7.22
+certifi==2024.8.30
+    # via
+    #   httpcore
+    #   httpx
+    #   requests
+charset-normalizer==3.4.0
     # via requests
-charset-normalizer==3.2.0
-    # via requests
-cosl==0.0.11
+cosl==0.0.45
     # via -r requirements.in
-idna==3.4
-    # via requests
-importlib-resources==6.0.1
+exceptiongroup==1.2.2
+    # via anyio
+h11==0.14.0
+    # via httpcore
+httpcore==1.0.7
+    # via httpx
+httpx==0.28.0
+    # via lightkube
+idna==3.10
+    # via
+    #   anyio
+    #   httpx
+    #   requests
+importlib-resources==6.4.5
     # via jsonschema
 jsonschema==4.17.3
     # via serialized-data-interface
+lightkube==0.15.5
+    # via cosl
+lightkube-models==1.31.1.8
+    # via lightkube
 oci-image==1.0.0
     # via -r requirements.in
-ops==2.14.0
+ops==2.17.1
     # via
     #   -r requirements.in
     #   cosl
     #   serialized-data-interface
 pkgutil-resolve-name==1.3.10
     # via jsonschema
-pyrsistent==0.19.3
+pydantic==2.10.2
+    # via cosl
+pydantic-core==2.27.1
+    # via pydantic
+pyrsistent==0.20.0
     # via jsonschema
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
     #   cosl
+    #   lightkube
     #   ops
     #   serialized-data-interface
-requests==2.31.0
+requests==2.32.3
     # via serialized-data-interface
 serialized-data-interface==0.7.0
     # via -r requirements.in
-typing-extensions==4.11.0
+sniffio==1.3.1
+    # via anyio
+tenacity==9.0.0
     # via cosl
-urllib3==2.0.4
+typing-extensions==4.12.2
+    # via
+    #   annotated-types
+    #   anyio
+    #   cosl
+    #   pydantic
+    #   pydantic-core
+urllib3==2.2.3
     # via requests
-websocket-client==1.6.1
+websocket-client==1.8.0
     # via ops
-zipp==3.16.2
+zipp==3.20.2
     # via importlib-resources

--- a/tox.ini
+++ b/tox.ini
@@ -38,6 +38,8 @@ commands =
     bash -c 'for pattern in "requirements.in" "requirements-fmt.in" "requirements*.in"; do find . -type f -name "$pattern" -exec bash -c "cd \$(dirname "{}") && pip-compile --resolver=backtracking \$(basename "{}")" \;; done'
 deps =
     pip-tools
+    # Pin due to https://github.com/jazzband/pip-tools/issues/2131
+    pip==24.2
 description = Update requirements files by executing pip-compile on all requirements*.in files, including those in subdirs.
 
 [testenv:fmt]


### PR DESCRIPTION
* Bump juju to 3.6/stable
* Pin pip to 24.2 due to https://github.com/jazzband/pip-tools/issues/2131
* Bump dependencies using 'tox -e update-requirements'

Ref canonical/bundle-kubeflow#1156