### PR TITLE
fix: Set the gid of mounted /data with fsGroup

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -27,7 +27,7 @@ jobs:
         sudo apt install tox
     - name: Lint code
       run: tox -vve lint
-  
+
   terraform-checks:
     name: Terraform
     uses: canonical/charmed-kubeflow-workflows/.github/workflows/terraform-checks.yaml@main
@@ -63,7 +63,7 @@ jobs:
 
       - name: Build and test
         run: |
-          sg snap_microk8s -c "tox -vve integration -- --model testing"
+          tox -vve integration -- --model testing
 
       # On failure, capture debugging resources
       - name: Get all

--- a/src/charm.py
+++ b/src/charm.py
@@ -121,6 +121,11 @@ class Operator(CharmBase):
                 }
             ],
             "kubernetesResources": {
+                "pod": {
+                    "securityContext": {
+                        "fsGroup": 2000,
+                    },
+                },
                 "secrets": [
                     {
                         "name": f"{self.model.app.name}-secret",
@@ -133,7 +138,7 @@ class Operator(CharmBase):
                             }.items()
                         },
                     },
-                ]
+                ],
             },
         }
 


### PR DESCRIPTION
Closes https://github.com/canonical/charmed-kubeflow-uats/issues/163

## Changes
1. Uses `fsGroup` in the PodSpec
2. Updates integration tests to call `kubectl` directly
## Review Notes
~~The `fsGroup` is also respected in MicroK8s.~~ This was **NOT true**! PTAL at https://github.com/canonical/minio-operator/pull/207#issuecomment-2717275949

For the test I tried to make it future proof by capturing the group of `/data` and ensuring the running process belongs to that group. To avoid hardcoding specific group numbers.

[This article](https://discourse.charmhub.io/t/updated-podspec-yaml-new-features/2124) was super helpful in helping understand how to set `fsGroup`.