### PR TITLE
chore: migrate GH runners to ubuntu 24.04

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -74,8 +74,9 @@ jobs:
 
       - name: Build and test
         run: |
+          # microk8s permissions required due to tests running `microk8s kubectl` commands  
           # `sg` does not work in GitHub Actions; use `sudo --user` instead
-          # See https://github.com/actions/runner-images/issues/9932#issuecomment-2573170305
+          # see https://github.com/actions/runner-images/issues/9932#issuecomment-2573170305
           sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- tox -vve integration -- --model testing
 
       # On failure, capture debugging resources

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Build and test
         run: |
-          # `newgrp` does not work in GitHub Actions; use `sudo --user` instead
+          # `sg` does not work in GitHub Actions; use `sudo --user` instead
           # See https://github.com/actions/runner-images/issues/9932#issuecomment-2573170305
           sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- tox -vve integration -- --model testing
 

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -74,10 +74,7 @@ jobs:
 
       - name: Build and test
         run: |
-          # microk8s permissions required due to tests running `microk8s kubectl` commands  
-          # `sg` does not work in GitHub Actions; use `sudo --user` instead
-          # see https://github.com/actions/runner-images/issues/9932#issuecomment-2573170305
-          sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- tox -vve integration -- --model testing
+          tox -vve integration -- --model testing
 
       # On failure, capture debugging resources
       - name: Get all

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -17,14 +17,17 @@ jobs:
 
   lint:
     name: Lint Code
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Check out code
       uses: actions/checkout@v3
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v5.3.0
+      with:
+        python-version: 3.8
     - name: Install dependencies
       run: |
-        sudo apt update
-        sudo apt install tox
+        pip install tox
     - name: Lint code
       run: tox -vve lint
   
@@ -36,10 +39,14 @@ jobs:
 
   unit:
     name: Unit Tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out code
         uses: actions/checkout@v3
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v5.3.0
+        with:
+          python-version: 3.8
       - name: Install dependencies
         run: |
           pip install tox
@@ -48,10 +55,14 @@ jobs:
 
   integration:
     name: Integration Test (deploy and access)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out code
         uses: actions/checkout@v3
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v5.3.0
+        with:
+          python-version: 3.8
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
@@ -63,7 +74,9 @@ jobs:
 
       - name: Build and test
         run: |
-          sg snap_microk8s -c "tox -vve integration -- --model testing"
+          # `newgrp` does not work in GitHub Actions; use `sudo --user` instead
+          # See https://github.com/actions/runner-images/issues/9932#issuecomment-2573170305
+          sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- tox -vve integration -- --model testing
 
       # On failure, capture debugging resources
       - name: Get all

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -28,7 +28,7 @@ on:
 jobs:
   get-charm-paths:
     name: Generate the Charm Matrix
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     outputs:
       charm_paths_list: ${{ steps.get-charm-paths.outputs.CHARM_PATHS_LIST }}
     steps:
@@ -43,7 +43,7 @@ jobs:
 
   publish-charm:
     name: Publish Charm
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: get-charm-paths
     strategy:
       fail-fast: false
@@ -83,6 +83,12 @@ jobs:
           echo "setting output of tag_prefix=$tag_prefix"
           echo "::set-output name=tag_prefix::$tag_prefix"
 
+      # Required to charmcraft pack in non-destructive mode
+      - name: Setup lxd
+        uses: canonical/setup-lxd@v0.1.2
+        with:
+          channel: latest/stable
+
       - name: Upload charm to charmhub
         uses: canonical/charming-actions/upload-charm@2.6.2
         with:
@@ -92,3 +98,4 @@ jobs:
           channel: ${{ steps.parse-inputs.outputs.destination_channel }}
           tag-prefix: ${{ steps.parse-inputs.outputs.tag_prefix }}
           charmcraft-channel: 3.x/stable
+          destructive-mode: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ on:
 jobs:
   promote-charm:
     name: Promote charm
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
       - name: Release charm to channel

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -14,7 +14,7 @@ resources:
     type: oci-image
     description: Backing OCI image
     auto-fetch: true
-    upstream-source: minio/minio:RELEASE.2021-09-03T03-56-13Z
+    upstream-source: docker.io/charmedkubeflow/minio:ckf-1.10-a385825
 provides:
   object-storage:
     interface: object-storage

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -114,7 +114,6 @@ async def connect_client_to_server(
     )
 
     kubectl_cmd = (
-        "microk8s",
         "kubectl",
         "run",
         "--rm",
@@ -180,7 +179,6 @@ async def test_connect_to_console(ops_test: OpsTest):
     url = f"http://{service_name}.{model_name}.svc.cluster.local:{port}"
 
     kubectl_cmd = (
-        "microk8s",
         "kubectl",
         "run",
         "--rm",


### PR DESCRIPTION
Closes #206 
* update GH runners from 20.04 to 24.04
* use setup-python action to setup python 3.8
* edit the integration tests to use `kubectl` instead of `microk8s kubectl` so that elevated permissions are not needed
* removes `sg` no longer needed based on the previous point