### PR TITLE
fix: integrate minio:ckf-1.10-b40ac43 to fix permission issue

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -14,7 +14,7 @@ resources:
     type: oci-image
     description: Backing OCI image
     auto-fetch: true
-    upstream-source: docker.io/charmedkubeflow/minio:ckf-1.10-a385825
+    upstream-source: docker.io/charmedkubeflow/minio:ckf-1.10-b40ac43
 provides:
   object-storage:
     interface: object-storage


### PR DESCRIPTION
Integrating this rock image guarantees that the minio workload will have access to the mounted storage to start the service correctly.

Part of canonical/charmed-kubeflow-uats#163