### PR TITLE
chore: Update `charmed_kubeflow_chisme` in requirements

### DIFF
--- a/requirements-integration.in
+++ b/requirements-integration.in
@@ -6,4 +6,6 @@ pytest
 pytest-operator
 pyyaml
 tenacity
-charmed-kubeflow-chisme>=0.4.10
+# "charmed-kubeflow-chisme" pinned to avoid closed "latest" tracks with COS charms, see:
+# https://github.com/canonical/charmed-kubeflow-chisme/issues/155
+charmed-kubeflow-chisme>=0.4.11

--- a/requirements-integration.txt
+++ b/requirements-integration.txt
@@ -26,7 +26,7 @@ cffi==1.17.1
     # via
     #   cryptography
     #   pynacl
-charmed-kubeflow-chisme==0.4.10
+charmed-kubeflow-chisme==0.4.11
     # via -r requirements-integration.in
 charset-normalizer==3.4.0
     # via requests


### PR DESCRIPTION
This PR updates charmed_kubeflow_chisme to fix https://github.com/canonical/charmed-kubeflow-chisme/issues/155