### PR TITLE
fix: handle missing oci-image case

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -56,13 +56,13 @@ class Operator(CharmBase):
         ]:
             self.framework.observe(event, self.main)
 
-    def main(self, event):
+    def main(self):
         try:
             self._check_leader()
 
             interfaces = self._get_interfaces()
 
-            image_details = self._check_image_details(event)
+            image_details = self._check_image_details()
 
             minio_args = self._get_minio_args()
 
@@ -162,7 +162,7 @@ class Operator(CharmBase):
             raise CheckFailed(str(err), BlockedStatus)
         return interfaces
 
-    def _check_image_details(self, event):
+    def _check_image_details(self):
         try:
             image_details = self.image.fetch()
         except OCIImageResourceError as e:

--- a/src/charm.py
+++ b/src/charm.py
@@ -61,7 +61,7 @@ class Operator(CharmBase):
 
             interfaces = self._get_interfaces()
 
-            image_details = self._check_image_details()
+            image_details = self._check_image_details(event)
 
             minio_args = self._get_minio_args()
 
@@ -161,11 +161,13 @@ class Operator(CharmBase):
             raise CheckFailed(str(err), BlockedStatus)
         return interfaces
 
-    def _check_image_details(self):
+    def _check_image_details(self, event):
         try:
             image_details = self.image.fetch()
         except OCIImageResourceError as e:
-            raise CheckFailed(f"{e.status_message}: oci-image", e.status_type)
+            self.log.error(f"Failed to fetch oci-image with: {e.status_message}, deferring..")
+            event.defer()
+            raise CheckFailed(f"{e.status_message}: oci-image", MaintenanceStatus)
         return image_details
 
     def _send_info(self, interfaces, secret_key):

--- a/src/charm.py
+++ b/src/charm.py
@@ -49,6 +49,7 @@ class Operator(CharmBase):
             self.on.config_changed,
             self.on.install,
             self.on.upgrade_charm,
+            self.on.update_status,
             self.on.leader_elected,
             self.on["object-storage"].relation_changed,
             self.on["object-storage"].relation_joined,
@@ -165,9 +166,8 @@ class Operator(CharmBase):
         try:
             image_details = self.image.fetch()
         except OCIImageResourceError as e:
-            self.log.error(f"Failed to fetch oci-image with: {e.status_message}, deferring..")
-            event.defer()
-            raise CheckFailed(f"{e.status_message}: oci-image", MaintenanceStatus)
+            self.log.error(f"Failed to fetch oci-image with: {e.status_message}")
+            raise CheckFailed(f"{e.status_message}: oci-image", WaitingStatus)
         return image_details
 
     def _send_info(self, interfaces, secret_key):

--- a/src/charm.py
+++ b/src/charm.py
@@ -56,7 +56,7 @@ class Operator(CharmBase):
         ]:
             self.framework.observe(event, self.main)
 
-    def main(self):
+    def main(self, event):
         try:
             self._check_leader()
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, PropertyMock
 
 import pytest
 import yaml
-from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
+from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
 from ops.testing import Harness
 
 from charm import Operator
@@ -25,7 +25,7 @@ def test_not_leader(harness):
 def test_missing_image(harness):
     harness.set_leader(True)
     harness.begin_with_initial_hooks()
-    assert harness.charm.model.unit.status == BlockedStatus("Missing resource: oci-image")
+    assert harness.charm.model.unit.status == MaintenanceStatus("Missing resource: oci-image")
 
 
 def test_main_no_relation(harness):

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, PropertyMock
 
 import pytest
 import yaml
-from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
+from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 from ops.testing import Harness
 
 from charm import Operator
@@ -25,7 +25,7 @@ def test_not_leader(harness):
 def test_missing_image(harness):
     harness.set_leader(True)
     harness.begin_with_initial_hooks()
-    assert harness.charm.model.unit.status == MaintenanceStatus("Missing resource: oci-image")
+    assert harness.charm.model.unit.status == WaitingStatus("Missing resource: oci-image")
 
 
 def test_main_no_relation(harness):


### PR DESCRIPTION
Closes #253 
For details on the fix and root cause, see #253

Tested in https://github.com/canonical/charmed-kubeflow-solutions/pull/62, specifically https://github.com/canonical/charmed-kubeflow-solutions/commit/c212429a0fafeef041ae9d3e33b9224904ad8cb9

## Summary
* adds `update_status` to the charm's observed events
* on failure to find the oci image, sets the status to `waiting` rather than `blocked` due to no human intervention being expected