### PR TITLE
Update chisme in requirements (#241)

### DIFF
--- a/requirements-integration.in
+++ b/requirements-integration.in
@@ -7,6 +7,6 @@ requests
 selenium
 selenium-wire
 tenacity
-# Pin to >=0.4.0 because the reusable test infrastructure is on that version and above
-# This prevents pip-compile from trying to pin an earlier version
-charmed-kubeflow-chisme>=0.4.0
+# "charmed-kubeflow-chisme" pinned to avoid closed "latest" tracks with COS charms, see:
+# https://github.com/canonical/charmed-kubeflow-chisme/issues/155
+charmed-kubeflow-chisme>=0.4.11

--- a/requirements-integration.txt
+++ b/requirements-integration.txt
@@ -37,7 +37,7 @@ cffi==1.17.1
     # via
     #   cryptography
     #   pynacl
-charmed-kubeflow-chisme==0.4.3
+charmed-kubeflow-chisme==0.4.11
     # via -r requirements-integration.in
 charset-normalizer==3.4.0
     # via requests


### PR DESCRIPTION
Cherry pick of #241 to `track/ckf-1.10`, currently the CI is [broken](https://github.com/canonical/minio-operator/actions/runs/17240091470) due to deploying from the deprecated COS channel. See https://github.com/canonical/charmed-kubeflow-chisme/issues/155 for details.