### PR TITLE
fix: Have relation component depend on pebble component

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -77,23 +77,6 @@ class MinIOOperator(CharmBase):
             depends_on=[self.leadership_gate],
         )
 
-        self.object_storage_relation = self.charm_reconciler.add(
-            component=SdiRelationBroadcasterComponent(
-                charm=self,
-                name="relation:object_storage",
-                relation_name="object-storage",
-                data_to_send={
-                    "port": self.model.config["port"],
-                    "secure": False,
-                    "access-key": self.model.config["access-key"],
-                    "secret-key": secret_key,
-                    "namespace": self.model.name,
-                    "service": self.model.app.name,
-                },
-            ),
-            depends_on=[self.leadership_gate, self.service_patcher],
-        )
-
         self.minio_container = self.charm_reconciler.add(
             component=MinIOPebbleService(
                 charm=self,
@@ -111,8 +94,24 @@ class MinIOOperator(CharmBase):
             depends_on=[
                 self.leadership_gate,
                 self.service_patcher,
-                self.object_storage_relation,
             ],
+        )
+
+        self.object_storage_relation = self.charm_reconciler.add(
+            component=SdiRelationBroadcasterComponent(
+                charm=self,
+                name="relation:object_storage",
+                relation_name="object-storage",
+                data_to_send={
+                    "port": self.model.config["port"],
+                    "secure": False,
+                    "access-key": self.model.config["access-key"],
+                    "secret-key": secret_key,
+                    "namespace": self.model.name,
+                    "service": self.model.app.name,
+                },
+            ),
+            depends_on=[self.leadership_gate, self.service_patcher, self.minio_container],
         )
 
         self.prometheus_provider = MetricsEndpointProvider(


### PR DESCRIPTION
## Summary

This PR swaps the edge on the component graph from:
- `SdiRelationComponent -> PebbleServiceComponent`
to:
- `PebbleServiceComponent -> SdiRelationComponent`

The current state caused some issues with `kfp-api` where the `apiserver` container tries to create a Bucket without being able to communicate with the `minio` service which is not yet reachable.

Closes https://github.com/canonical/kfp-operators/issues/872